### PR TITLE
Efficiency improvement for uncoloured trees

### DIFF
--- a/src/beast/evolution/speciation/BirthDeathMigrationModel.java
+++ b/src/beast/evolution/speciation/BirthDeathMigrationModel.java
@@ -1,5 +1,6 @@
 package beast.evolution.speciation;
 
+import java.util.Collections;
 
 import beast.core.Description;
 import beast.core.util.Utils;
@@ -8,6 +9,7 @@ import beast.core.Input;
 
 import beast.math.SmallNumber;
 import beast.math.p0ge_InitialConditions;
+import beast.util.HeapSort;
 
 
 
@@ -29,6 +31,8 @@ public class BirthDeathMigrationModel extends PiecewiseBirthDeathMigrationDistri
 
 	MultiTypeTree coltree;
 	MultiTypeRootBranch originBranch;
+	
+	double[][] pInitialConditionsOnMigrationEvents;
 
 	Boolean print = false;
 
@@ -65,7 +69,6 @@ public class BirthDeathMigrationModel extends PiecewiseBirthDeathMigrationDistri
 		setRho();
 
 	}
-
 
 	double updateRates(){
 
@@ -142,8 +145,19 @@ public class BirthDeathMigrationModel extends PiecewiseBirthDeathMigrationDistri
 	 */
 	public p0ge_InitialConditions getGSmallNumber(double t, p0ge_InitialConditions PG0, double t0, Node node){ // PG0 contains initial condition for p0 (0..n-1) and for ge (n..2n-1)
 
-		if (node.isLeaf())
-			System.arraycopy(PG.getP(t0, m_rho.get()!=null, rho), 0, PG0.conditionsOnP, 0, n);
+		if (node.isLeaf()){
+			// TO DO CLEAN UP
+			//System.arraycopy(PG.getP(t0, m_rho.get()!=null, rho), 0, PG0.conditionsOnP, 0, n);
+			double h = T - node.getHeight();
+			double[] temp = PG.getP(t0, m_rho.get()!=null, rho);
+			double[] temp2 = pInitialConditions[node.getNr()];
+			
+			if (h!=t0) {
+				throw new RuntimeException("t0 est pas comme height");
+			}
+			
+			System.arraycopy(pInitialConditions[node.getNr()], 0, PG0.conditionsOnP, 0, n);
+		}
 
 		return getGSmallNumber(t,  PG0,  t0, pg_integrator, PG, T, maxEvalsUsed);
 	}
@@ -151,7 +165,7 @@ public class BirthDeathMigrationModel extends PiecewiseBirthDeathMigrationDistri
 
 	/**
 	 * WARNING: calculateTreeLogLikelihood allows use of both classic and non-underflowing methods. Some chunks of code are therefore present in two similar versions in this method.
-	 * When modifying one of the versions, one should check if the other version also need the corresponding changes.
+	 * When modifying one of the two versions, one should check if the other version also need the corresponding changes.
 	 */
 	@Override
 	public double calculateTreeLogLikelihood(TreeInterface tree) {
@@ -194,9 +208,15 @@ public class BirthDeathMigrationModel extends PiecewiseBirthDeathMigrationDistri
 
 		try{  // start calculation
 
+			//pInitialConditions = getAllInitialConditionsForP(tree);
+
 			if (conditionOnSurvival.get()) {
 
-				// since noSampleExistsProp has to be a double, and there is hardly any risk of significant underflowing with getP, the SmallNumber implementation is not used for this step in any case
+//				if (orig > 0) // the root is at height 0
+//					noSampleExistsProp = pInitialConditions[tree.getNodeCount()];
+//				else // the root is higher than zero
+//					noSampleExistsProp = pInitialConditions[root.getNr()];
+
 				noSampleExistsProp = PG.getP(0,m_rho.get()!= null,rho);
 
 				if (print) System.out.println("\nnoSampleExistsProp = " + noSampleExistsProp[0]);// + ", " + noSampleExistsProp[1]);
@@ -207,7 +227,7 @@ public class BirthDeathMigrationModel extends PiecewiseBirthDeathMigrationDistri
 				}
 			}
 
-			// alternatively p or pSN will be used, depending if the user wants to use the classic implementation or the one with SmallNumbers
+			// alternatively p or pSN will be used, depending on whether the user wants to use the classic implementation or the one with SmallNumbers
 			p0ge_InitialConditions pSN = new p0ge_InitialConditions();
 			double [] p = new double[] {0};
 
@@ -247,8 +267,7 @@ public class BirthDeathMigrationModel extends PiecewiseBirthDeathMigrationDistri
 
 				if (useSmallNumbers.get()) {
 					p0ge_InitialConditions p1SN = calculateSubtreeLikelihoodSmallNumber(root.getChild(childIndex), false, null, 0., t0);
-					
-					// Warning: stopped multiplying for p conditions: should not change anything but still, check that it works
+
 					for (int i=0; i<pSN.conditionsOnG.length; i++) pSN.conditionsOnG[i] = SmallNumber.multiply(pSN.conditionsOnG[i], p1SN.conditionsOnG[i]);
 
 				} else {
@@ -514,13 +533,13 @@ public class BirthDeathMigrationModel extends PiecewiseBirthDeathMigrationDistri
 
 					if (!isRhoTip[node.getNr()]){
 						init.conditionsOnG[nodestate] = SAModel
-						? new SmallNumber((r[nodestate * totalIntervals + index] + PG.getP(to, m_rho.get()!=null, rho)[nodestate]*(1-r[nodestate * totalIntervals + index]))
-								*psi[nodestate * totalIntervals + index])
+								? new SmallNumber((r[nodestate * totalIntervals + index] + pInitialConditions[node.getNr()][nodestate]*(1-r[nodestate * totalIntervals + index]))
+										*psi[nodestate * totalIntervals + index])
 
-								: new SmallNumber(psi[nodestate * totalIntervals + index]);
+										: new SmallNumber(psi[nodestate * totalIntervals + index]);
 
 					} else {
-							init.conditionsOnG[nodestate] = new SmallNumber(rho[nodestate*totalIntervals+index]);
+						init.conditionsOnG[nodestate] = new SmallNumber(rho[nodestate*totalIntervals+index]);
 					}
 
 					if (print) System.out.println("Sampling at time " + to);
@@ -587,5 +606,67 @@ public class BirthDeathMigrationModel extends PiecewiseBirthDeathMigrationDistri
 		return true;
 	}
 
-
+	// TO DO remove if not useful in the end
+//	public void getAllInitialConditions(TreeInterface tree){
+//		int nodeCount = tree.getNodeCount();
+//        double[] nodeHeights = new double[nodeCount];
+//        int[] indicesSortedByNodeHeight  =new int[nodeCount];
+//        for (int i=0; i<nodeCount; i++){
+//        	nodeHeights[i] = T - tree.getNode(i).getHeight();
+//        	// System.out.println(nodeHeight[i]);
+//        	indicesSortedByNodeHeight[i] = i;
+//        }
+//        
+//
+////        double[] tempMigChangeTimes = Collections.sort(migChangeTimes);
+////        migChangeTimes
+//        
+//        HeapSort.sort(nodeHeights, indicesSortedByNodeHeight);
+//        //"sort" sorts in ascending order, so we have to be careful since the integration starts from the leaves at height T and goes up to the root at height 0 (or >0)
+//        
+//        int nodePlength = (nodeHeights[indicesSortedByNodeHeight[0]] == 0)? nodeCount: nodeCount + 1; // in case the origin is not at zero, an extra space is left for the value of integration till 0. 
+//        double[][] nodePInitials = new double[nodePlength][n]; 
+//        
+//        double t = nodeHeights[indicesSortedByNodeHeight[nodeCount-1]];
+//        
+//        boolean rhoSampling =  (m_rho.get()!=null);
+//        
+//        nodePInitials[indicesSortedByNodeHeight[nodeCount-1]] = PG.getP(t, rhoSampling, rho);
+//        double t0 = t;
+//        
+//        if (nodeCount >1 ){
+//            for (int i = nodeCount-2; i>-1; i--){
+//            	t = nodeHeights[indicesSortedByNodeHeight[i]];
+//            	
+//            	//If the next higher node is actually at the same height, store previous results and skip iteration
+//            	if (Math.abs(t-t0) < 1e-10) {
+//            		t0 = t;
+//            		nodePInitials[indicesSortedByNodeHeight[i]] = nodePInitials[indicesSortedByNodeHeight[i+1]];
+//            		continue;
+//            	} else {
+//            		nodePInitials[indicesSortedByNodeHeight[i]] = PG.getP(t, nodePInitials[indicesSortedByNodeHeight[i+1]], t0, rhoSampling, rho);
+//            		t0 = t;
+//            	}
+//                
+//            }
+//        }
+//        
+//        if (nodePlength > nodeCount) {
+//        	nodePInitials[nodeCount] = PG.getP(0, nodePInitials[indicesSortedByNodeHeight[0]], t0, rhoSampling, rho);
+//        }
+//        
+//        pInitialConditions = nodePInitials;
+//        
+//        
+//
+////        String sortedIndices = new String();
+////        for (int d: indicesSortedByNodeHeight) {
+////        	sortedIndices += (d + "\t");
+////        }
+////        System.out.println("Node indices sorted: " + sortedIndices);
+////        for (int i = 0; i<nodeCount; i++) {
+////        	System.out.println("Value of node " + i + ":\t" + nodePInitials[i][0]);
+////        }
+//
+//	}
 }

--- a/src/beast/evolution/speciation/BirthDeathMigrationModel.java
+++ b/src/beast/evolution/speciation/BirthDeathMigrationModel.java
@@ -146,17 +146,17 @@ public class BirthDeathMigrationModel extends PiecewiseBirthDeathMigrationDistri
 	public p0ge_InitialConditions getGSmallNumber(double t, p0ge_InitialConditions PG0, double t0, Node node){ // PG0 contains initial condition for p0 (0..n-1) and for ge (n..2n-1)
 
 		if (node.isLeaf()){
-			// TO DO CLEAN UP
-			//System.arraycopy(PG.getP(t0, m_rho.get()!=null, rho), 0, PG0.conditionsOnP, 0, n);
-			double h = T - node.getHeight();
-			double[] temp = PG.getP(t0, m_rho.get()!=null, rho);
-			double[] temp2 = pInitialConditions[node.getNr()];
+//			// TO DO CLEAN UP
+//			//System.arraycopy(PG.getP(t0, m_rho.get()!=null, rho), 0, PG0.conditionsOnP, 0, n);
+//			double h = T - node.getHeight();
+//			double[] temp = PG.getP(t0, m_rho.get()!=null, rho);
+//			double[] temp2 = pInitialConditions[node.getNr()];
+//			
+//			if (h!=t0) {
+//				throw new RuntimeException("t0 est pas comme height");
+//			}
 			
-			if (h!=t0) {
-				throw new RuntimeException("t0 est pas comme height");
-			}
-			
-			System.arraycopy(pInitialConditions[node.getNr()], 0, PG0.conditionsOnP, 0, n);
+			System.arraycopy(PG.getP(t0, m_rho.get()!=null, rho), 0, PG0.conditionsOnP, 0, n);
 		}
 
 		return getGSmallNumber(t,  PG0,  t0, pg_integrator, PG, T, maxEvalsUsed);
@@ -533,7 +533,7 @@ public class BirthDeathMigrationModel extends PiecewiseBirthDeathMigrationDistri
 
 					if (!isRhoTip[node.getNr()]){
 						init.conditionsOnG[nodestate] = SAModel
-								? new SmallNumber((r[nodestate * totalIntervals + index] + pInitialConditions[node.getNr()][nodestate]*(1-r[nodestate * totalIntervals + index]))
+								? new SmallNumber((r[nodestate * totalIntervals + index] + PG.getP(to, m_rho.get()!=null, rho)[nodestate]*(1-r[nodestate * totalIntervals + index]))
 										*psi[nodestate * totalIntervals + index])
 
 										: new SmallNumber(psi[nodestate * totalIntervals + index]);

--- a/src/beast/evolution/speciation/BirthDeathMigrationModel.java
+++ b/src/beast/evolution/speciation/BirthDeathMigrationModel.java
@@ -1,7 +1,5 @@
 package beast.evolution.speciation;
 
-import java.util.Collections;
-
 import beast.core.Description;
 import beast.core.util.Utils;
 import beast.evolution.tree.*;

--- a/src/beast/evolution/speciation/PiecewiseBirthDeathMigrationDistribution.java
+++ b/src/beast/evolution/speciation/PiecewiseBirthDeathMigrationDistribution.java
@@ -12,6 +12,7 @@ import beast.evolution.tree.TreeInterface;
 import beast.math.p0_ODE;
 import beast.math.p0ge_InitialConditions;
 import beast.math.p0ge_ODE;
+import beast.util.HeapSort;
 import beast.math.ScaledNumbers;
 import beast.math.SmallNumber;
 import beast.math.SmallNumberScaler;
@@ -251,6 +252,9 @@ public abstract class PiecewiseBirthDeathMigrationDistribution extends SpeciesTr
 	Boolean birthAmongDemes = false;
 
 	Double[] freq;
+	
+	double[][] pInitialConditions;
+	double[] sortedNodes;
 
 
 	@Override
@@ -385,6 +389,8 @@ public abstract class PiecewiseBirthDeathMigrationDistribution extends SpeciesTr
 			if (Math.abs(T-t)<1e-10 || Math.abs(t0-t)<1e-10 ||  T < t) {
 				return PG0;
 			}
+			
+
 
 			double from = t;
 			double to = t0;
@@ -646,6 +652,7 @@ public abstract class PiecewiseBirthDeathMigrationDistribution extends SpeciesTr
 	/**
 	 * set change times
 	 */
+
 	public void getChangeTimes(double maxTime, List<Double> changeTimes, RealParameter intervalTimes, int numChanges, boolean relative, boolean reverse) {
 		changeTimes.clear();
 
@@ -1045,6 +1052,11 @@ public abstract class PiecewiseBirthDeathMigrationDistribution extends SpeciesTr
 	        if (values[i] < min && values[i]!=0 ) min=values[i];
 	    }
 	    return min;
+	}
+
+
+	public p0ge_ODE getPG() {
+		return PG;
 	}
 
 }


### PR DESCRIPTION
Implementation of a sweep preliminary to the calculation of a tree likelihood. During this sweep, the initial conditions for future integration steps on p equations are stored, and not recomputed later anymore. This improvement currently only applies to uncoloured trees.