### PR TITLE
changed birthRate and deathRate to Functions

### DIFF
--- a/src/beast/evolution/speciation/BirthDeathMigrationClusterModelUncoloured.java
+++ b/src/beast/evolution/speciation/BirthDeathMigrationClusterModelUncoloured.java
@@ -86,8 +86,8 @@ public class BirthDeathMigrationClusterModelUncoloured extends BirthDeathMigrati
 
 	protected Double updateRates(TreeInterface tree) {
 
-		birth = new Double[n*totalIntervals];
-		death = new Double[n*totalIntervals];
+		birth = new double[n*totalIntervals];
+		death = new double[n*totalIntervals];
 		psi = new Double[n*totalIntervals];
 		b_ij = new Double[totalIntervals*(n*(n-1))];
 		M = new Double[totalIntervals*(n*(n-1))];

--- a/src/beast/evolution/speciation/PiecewiseBirthDeathMigrationDistribution.java
+++ b/src/beast/evolution/speciation/PiecewiseBirthDeathMigrationDistribution.java
@@ -1,9 +1,6 @@
 package beast.evolution.speciation;
 
-import beast.core.Citation;
-import beast.core.Description;
-import beast.core.Input;
-import beast.core.State;
+import beast.core.*;
 import beast.core.parameter.BooleanParameter;
 import beast.core.parameter.RealParameter;
 import beast.core.util.Utils;
@@ -125,9 +122,9 @@ public abstract class PiecewiseBirthDeathMigrationDistribution extends SpeciesTr
 	public Input<Boolean> contemp =
 			new Input<>("contemp", "Only contemporaneous sampling (i.e. all tips are from same sampling time, default false)", false);
 
-	public Input<RealParameter> birthRate =
+	public Input<Function> birthRate =
 			new Input<>("birthRate", "BirthRate = BirthRateVector * birthRateScalar, birthrate can change over time");
-	public Input<RealParameter> deathRate =
+	public Input<Function> deathRate =
 			new Input<>("deathRate", "The deathRate vector with birthRates between times");
 	public Input<RealParameter> samplingRate =
 			new Input<>("samplingRate", "The sampling rate per individual");      // psi
@@ -221,8 +218,8 @@ public abstract class PiecewiseBirthDeathMigrationDistribution extends SpeciesTr
 	public static Double maxstep;
 
 	// these four arrays are totalIntervals in length
-	protected Double[] birth;
-	Double[] death;
+	protected double[] birth;
+	double[] death;
 	Double[] psi;
 	static  volatile Double[] rho;
 	Double[] r;
@@ -389,9 +386,9 @@ public abstract class PiecewiseBirthDeathMigrationDistribution extends SpeciesTr
 		} else if (birthRate.get() != null && deathRate.get() != null && samplingRate.get() != null) {
 
 			transform = false;
-			death = deathRate.get().getValues();
+			death = deathRate.get().getDoubleValues();
 			psi = samplingRate.get().getValues();
-			birth = birthRate.get().getValues();
+			birth = birthRate.get().getDoubleValues();
 			if (SAModel) r = removalProbability.get().getValues();
 
 			if (birthRateAmongDemes.get()!=null ){
@@ -784,8 +781,8 @@ public abstract class PiecewiseBirthDeathMigrationDistribution extends SpeciesTr
 
 	void updateBirthDeathPsiParams(){
 
-		Double[] birthRates = birthRate.get().getValues();
-		Double[] deathRates = deathRate.get().getValues();
+		double[] birthRates = birthRate.get().getDoubleValues();
+		double[] deathRates = deathRate.get().getDoubleValues();
 		Double[] samplingRates = samplingRate.get().getValues();
 		Double[] removalProbabilities = new Double[1];
 
@@ -1142,8 +1139,8 @@ public abstract class PiecewiseBirthDeathMigrationDistribution extends SpeciesTr
 
 	protected Double updateRates() {
 
-		birth = new Double[n*totalIntervals];
-		death = new Double[n*totalIntervals];
+		birth = new double[n*totalIntervals];
+		death = new double[n*totalIntervals];
 		psi = new Double[n*totalIntervals];
 		b_ij = new Double[totalIntervals*(n*(n-1))];
 		M = new Double[totalIntervals*(n*(n-1))];

--- a/src/beast/math/p0_ODE.java
+++ b/src/beast/math/p0_ODE.java
@@ -15,9 +15,9 @@ import beast.core.util.Utils;
 
 public class p0_ODE implements FirstOrderDifferentialEquations {
 
-	Double[] b;
+	double[] b;
 	Double[] b_ij;
-	Double[] d;
+	double[] d;
 	Double[] s;
 
 	Double[] M;
@@ -27,7 +27,7 @@ public class p0_ODE implements FirstOrderDifferentialEquations {
 	Double[] times;
 	int index;
 
-	public p0_ODE(Double[] b, Double[] b_ij, Double[] d, Double[] s, Double[] M, int dimension , int intervals, Double[] times) {
+	public p0_ODE(double[] b, Double[] b_ij, double[] d, Double[] s, Double[] M, int dimension , int intervals, Double[] times) {
 
 		this.b = b;
 		this.b_ij = b_ij;
@@ -42,7 +42,7 @@ public class p0_ODE implements FirstOrderDifferentialEquations {
 	}
 
 	// updateRates is not used here because a new p0_ODE is created each time PiecewiseBirthDeathMigrationDistribution.updateRates() is called (called through setUpIntegrators())
-	public void updateRates(Double[] b, Double[] b_ij, Double[] d, Double[] s, Double[] M, Double[] times){
+	public void updateRates(double[] b, Double[] b_ij, double[] d, Double[] s, Double[] M, Double[] times){
 
 		this.b = b;
 		this.b_ij = b_ij;
@@ -98,8 +98,8 @@ public class p0_ODE implements FirstOrderDifferentialEquations {
 	public static void main(String[] args) throws Exception{
 		
 		// 2d test
-		Double[] b = {1.03,1.06};
-		Double[] d = {1.,1.};
+		double[] b = {1.03,1.06};
+		double[] d = {1.,1.};
 		Double[] s = {0.02,0.04};
 		Double[] M = new Double[]{3.,4.};
 

--- a/src/beast/math/p0ge_ODE.java
+++ b/src/beast/math/p0ge_ODE.java
@@ -24,9 +24,9 @@ public class p0ge_ODE implements FirstOrderDifferentialEquations {
 	p0_ODE P;
 	public FirstOrderIntegrator p_integrator;
 
-	Double[] b;
+	double[] b;
 	Double[] b_ij;
-	Double[] d;
+	double[] d;
 	Double[] s;
 
 	Boolean augmented;
@@ -45,7 +45,7 @@ public class p0ge_ODE implements FirstOrderDifferentialEquations {
 	public static double globalPrecisionThreshold;
 
 
-	public p0ge_ODE(Double[] b, Double[] b_ij, Double[] d, Double[] s, Double[] M, int dimension, int intervals, double T, Double[] times, p0_ODE P, int maxEvals, Boolean augmented){
+	public p0ge_ODE(double[] b, Double[] b_ij, double[] d, Double[] s, Double[] M, int dimension, int intervals, double T, Double[] times, p0_ODE P, int maxEvals, Boolean augmented){
 
 
 		this.b = b;
@@ -260,8 +260,8 @@ public class p0ge_ODE implements FirstOrderDifferentialEquations {
 	 */
 	public static void testCorrelations(){
 
-		Double[] b;
-		Double[] d = {1.,1.};
+		double[] b;
+		double[] d = {1.,1.};
 		Double[] s;
 		Double[] M;// = {3.,3.};
 
@@ -273,7 +273,7 @@ public class p0ge_ODE implements FirstOrderDifferentialEquations {
 
 		for (double i =1.1; i<2; i+=0.125){
 
-			b = new Double[]{i, i};
+			b = new double[]{i, i};
 
 			//            psi = 0.5 * ((i - death[0]) - Math.sqrt((death[0] - i) * (death[0] - i) - .04));  // assume birth*sampling*m=constant
 
@@ -365,9 +365,9 @@ public class p0ge_ODE implements FirstOrderDifferentialEquations {
 
 		testCorrelations();
 
-		Double[] birth = {2.,2.};
-		Double[] b;
-		Double[] d = {.5,.5};
+		double[] birth = {2.,2.};
+		double[] b;
+		double[] d = {.5,.5};
 		Double[] s = {.5,.5};
 		Double[] M = {0.,0.};
 
@@ -377,7 +377,7 @@ public class p0ge_ODE implements FirstOrderDifferentialEquations {
 
 		int i = 1;
 
-		b = new Double[]{i*birth[0], i*birth[1]};
+		b = new double[]{i*birth[0], i*birth[1]};
 
 		FirstOrderIntegrator integrator = new DormandPrince853Integrator(1.0e-4, 1., 1.0e-6, 1.0e-6);//new ClassicalRungeKuttaIntegrator(.01); //
 


### PR DESCRIPTION
I have changed the birthRate and deathRate inputs to Functions. This allows them to be produced by expressions so that the parameterization for operators and priors could be something else (like diversification and turnover). Because of slight differences in available methods for Function and RealParameter it was easiest to change some downstream function inputs to double[] rather than Double[]. Ultimately this should be done for all the other canonical parameters.

A more efficient longer term solution to allow alternative parameterizations without interpretation would be for a Parameterization abstraction layer to be added. I started that in one of the other packages but didn't finish it :(