### PR TITLE
Added BEAUti template for tip-typed analyses

### DIFF
--- a/templates/MultiTypeBirthDeathUncoloured.xml
+++ b/templates/MultiTypeBirthDeathUncoloured.xml
@@ -104,94 +104,98 @@
                               beast.evolution.tree.coalescent.BayesianSkyline.groupSizes,
                               beast.evolution.tree.coalescent.BayesianSkyline.popSizes,
                               beast.evolution.speciation.YuleModel.originHeight,
-                              multitypetree.distributions.StructuredCoalescentTreeDensity.multiTypeTree,
-							beast.evolution.speciation.BirthDeathMigrationModel.treeIntervals,
-							beast.evolution.speciation.BirthDeathMigrationModel.tree,
-							beast.evolution.speciation.BirthDeathMigrationModel.useTipDates,
-							beast.evolution.speciation.BirthDeathMigrationModel.maxEvaluations,
-							beast.evolution.speciation.BirthDeathMigrationModel.checkRho,
-							beast.evolution.speciation.BirthDeathMigrationModel.origin,
-							beast.evolution.speciation.BirthDeathMigrationModel.originBranch,
-							beast.evolution.speciation.BirthDeathMigrationModel.originIsRootEdge,
-							beast.evolution.speciation.BirthDeathMigrationModel.tolerance,
-							beast.evolution.speciation.BirthDeathMigrationModel.migChangeTimes,
-							beast.evolution.speciation.BirthDeathMigrationModel.birthRateChangeTimes,
-							beast.evolution.speciation.BirthDeathMigrationModel.birthRateAmongDemesChangeTimes,
-							beast.evolution.speciation.BirthDeathMigrationModel.samplingRateChangeTimes,
-							beast.evolution.speciation.BirthDeathMigrationModel.deathRateChangeTimes,
-							beast.evolution.speciation.BirthDeathMigrationModel.removalProbabilityChangeTimes,
-							beast.evolution.speciation.BirthDeathMigrationModel.intervalTimes,
-							beast.evolution.speciation.BirthDeathMigrationModel.migTimesRelative,
-							beast.evolution.speciation.BirthDeathMigrationModel.birthRateTimesRelative,
-							beast.evolution.speciation.BirthDeathMigrationModel.birthRateAmongDemesTimesRelative,
-							beast.evolution.speciation.BirthDeathMigrationModel.deathRateTimesRelative,
-							beast.evolution.speciation.BirthDeathMigrationModel.samplingRateTimesRelative,
-							beast.evolution.speciation.BirthDeathMigrationModel.rhoSamplingTimes,
-							beast.evolution.speciation.BirthDeathMigrationModel.coupledR0Changes,
-							beast.evolution.speciation.BirthDeathMigrationModel.removalAffectsSamplingProportion,
-							beast.evolution.speciation.BirthDeathMigrationModel.removalProbability,
-							beast.evolution.speciation.BirthDeathMigrationModel.adjustTimes,
-							beast.evolution.speciation.BirthDeathMigrationModel.useRK,
-							beast.evolution.speciation.BirthDeathMigrationModel.adjustTimes,
-							beast.evolution.speciation.BirthDeathMigrationModel.rho,
-							beast.evolution.speciation.BirthDeathMigrationModel.contemp,
-							beast.evolution.speciation.BirthDeathMigrationModel.birthRate,
-							beast.evolution.speciation.BirthDeathMigrationModel.birthRateAmongDemes,
-							beast.evolution.speciation.BirthDeathMigrationModel.R0AmongDemes,
-							beast.evolution.speciation.BirthDeathMigrationModel.deathRate,
-							beast.evolution.speciation.BirthDeathMigrationModel.samplingRate,
-							beast.evolution.speciation.BirthDeathMigrationModel.R0,
-							beast.evolution.speciation.BirthDeathMigrationModel.samplingProportion,
-							beast.evolution.speciation.BirthDeathMigrationModel.becomeUninfectiousRate,
-							beast.evolution.speciation.BirthDeathMigrationModel.migrationMatrix,
-							beast.evolution.speciation.BirthDeathMigrationModel.frequencies,
-							beast.evolution.speciation.BirthDeathMigrationModel.reverseTimeArrays,
-							beast.evolution.speciation.BirthDeathMigrationModel.stateNumber
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.treeIntervals,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.tree,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.useTipDates,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.maxEvaluations,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.checkRho,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.origin,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.originIsRootEdge,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.tolerance,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.migChangeTimes,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.birthRateChangeTimes,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.birthRateAmongDemesChangeTimes,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.samplingRateChangeTimes,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.deathRateChangeTimes,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.removalProbabilityChangeTimes,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.intervalTimes,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.migTimesRelative,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.birthRateTimesRelative,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.birthRateAmongDemesTimesRelative,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.deathRateTimesRelative,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.samplingRateTimesRelative,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.rhoSamplingTimes,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.coupledR0Changes,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.removalAffectsSamplingProportion,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.removalProbability,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.adjustTimes,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.useRK,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.adjustTimes,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.rho,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.contemp,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.birthRate,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.birthRateAmongDemes,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.R0AmongDemes,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.deathRate,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.samplingRate,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.frequencies,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.reverseTimeArrays,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.R0_base,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.lambda_ratio,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.migrationMatrixScaleFactor,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.rateMatrixFlags,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.parallelize,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.parallelizationFactor,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.typeLabel,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.tiptypes,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.tipTypeArray,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.storeNodeTypes,
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.identicalRatesForAllTypes
 							'>
                                       
         <panel spec='BeautiPanelConfig' panelname="Partitions" tiptext="Data Partitions"
             path='distribution/distribution[id="likelihood"]/distribution/data'
-            hasPartitions="none" icon='2220.png.x' forceExpansion='FALSE'
+            hasPartitions="none" forceExpansion='FALSE'
             type='beast.evolution.alignment.Alignment'
             />
 
 		<panel spec='BeautiPanelConfig' panelname="Tip Dates" tiptext="Specify times at which taxa were sampled"
             path='tree'
-            hasPartitions="Tree" icon='2.png.x' forceExpansion='TRUE'
+            hasPartitions="Tree" forceExpansion='TRUE'
             isVisible='true'
         />
 
 		<panel spec='BeautiPanelConfig' panelname="Tip Locations" tiptext="Specify locations from which taxa were sampled"
-            path='tree/typeTrait'
-            hasPartitions="Tree" icon='2.png.x' forceExpansion='TRUE'
+            path='distribution/distribution[id="prior"]/distribution[type="beast.evolution.speciation.BirthDeathMigrationModelUncoloured"]/tiptypes'
+            hasPartitions="none" forceExpansion='TRUE'
             isVisible='true'
         />
 
         <panel spec='BeautiPanelConfig' panelname="Site Model" tiptext="Site model and substitution model specifications"
             path='siteModel'
-            hasPartitions="SiteModel" icon='3.png.x' forceExpansion='TRUE'
+            hasPartitions="SiteModel" forceExpansion='TRUE'
             />
 
         <panel spec='BeautiPanelConfig' panelname="Clock Model" tiptext="Clock model"
             path='branchRateModel'
-            hasPartitions="ClockModel" icon='4.png.x' forceExpansion='TRUE'
+            hasPartitions="ClockModel" forceExpansion='TRUE'
         />
 
         <panel spec='BeautiPanelConfig' panelname="Priors" tiptext="Other priors"
             path='distribution/distribution[id="prior"]/distribution'
-            hasPartitions="none" icon='7.png.x' forceExpansion='TRUE_START_COLLAPSED'
+            hasPartitions="none" forceExpansion='TRUE_START_COLLAPSED'
             type='beast.core.Distribution'
         />
 
         <panel spec='BeautiPanelConfig' panelname="Operators" tiptext="MCMC Operator details"
             path='operator'
-            hasPartitions="none" icon='8.png.x' forceExpansion='TRUE_START_COLLAPSED'
+            hasPartitions="none" forceExpansion='TRUE_START_COLLAPSED'
             isVisible='false' buttonStatus='ADD_ONLY'
         />
 
 		<panel spec='BeautiPanelConfig' panelname="MCMC" tiptext="MCMC parameters"
             path=''
-            hasPartitions="none" icon='9.png.x' forceExpansion='TRUE'
+            hasPartitions="none" forceExpansion='TRUE'
             />
 
 		<alignmentProvider id="Add Alignment" spec='BeautiAlignmentProvider' template='@StandardPartitionTemplate'/>
@@ -203,6 +207,7 @@
 
             <plugin spec='beast.evolution.tree.RandomTree' id='Tree.t:$(n)' estimate='true'>
                 <taxa idref='data'/>
+                <taxonset id='taxonSet.$(n)' spec="beast.evolution.alignment.TaxonSet" alignment="@data"/>
                 <populationModel id='ConstantPopulation0.t:$(n)' spec='ConstantPopulation'>
             		<popSize id='randomPopSize.t:$(n)' spec='parameter.RealParameter' value='1'/>
 	            </populationModel>
@@ -227,11 +232,15 @@
 
             <distribution spec="beast.evolution.speciation.BirthDeathMigrationModelUncoloured" id="birthDeathMigration.t:$(n)" tree="@Tree.t:$(n)"
 				  stateNumber="2" conditionOnSurvival="true">
+				  <tiptypes spec="beast.evolution.tree.TraitSet" traitname="type" id="typeTraitSet.t:$(n)" value="">
+                      <taxa idref="taxonSet.$(n)"/>
+				  </tiptypes>
                 <migrationMatrix spec="beast.core.parameter.RealParameter" id="rateMatrix.t:$(n)" value="0.01" dimension="2" lower="0" upper="100"/>
-                <parameter name="frequencies" id="geo-frequencies.t:$(n)" value=".5 .5" lower="0." upper="1." dimension="2"/>
-                <parameter name="R0" id="R0.t:$(n)" lower="0" dimension="2" value="3"/>
-                <parameter name="becomeUninfectiousRate" id="becomeUninfectiousRate.t:$(n)" value=".1" lower="0" dimension="2" />
-                <parameter name="samplingProportion" id="samplingProportion.t:$(n)" value="0.05 0.15" lower="0" dimension="2"  upper="1."/>
+                <frequencies spec="parameter.RealParameter" id="geo-frequencies.t:$(n)" value=".5 .5" lower="0." upper="1." dimension="2"/>
+                <R0 spec="parameter.RealParameter" id="R0.t:$(n)" lower="0" dimension="2" value="1.5"/>
+                <becomeUninfectiousRate spec="parameter.RealParameter" id="becomeUninfectiousRate.t:$(n)" value="0.1" lower="0" dimension="2" />
+                <samplingProportion spec="parameter.RealParameter" id="samplingProportion.t:$(n)" value="0.05" lower="0" dimension="2"  upper="1."/>
+                <rho spec="parameter.RealParameter" id="rho.t:$(n)" value="0.5" dimension="2"/>
             </distribution>
 
 
@@ -281,6 +290,14 @@
 				</distr>	
             </prior>
 
+            <prior id='rhoPrior.t:$(n)' x='@rho.t:$(n)'>
+                <distr spec="beast.math.distributions.Uniform" lower="0" upper="1"/>
+            </prior>
+
+            <prior id="geo-frequenciesPrior.t:$(n)" x="@geo-frequencies.t:$(n)">
+                <distr spec="beast.math.distributions.Uniform" lower="0" upper="1"/>
+            </prior>
+
             <!-- Parameter operators -->
             
             <operator id='proportionInvariantScaler.s:$(n)' spec='ScaleOperator' scaleFactor="0.5" weight="0.1" parameter="@proportionInvariant.s:$(n)"/>
@@ -290,7 +307,8 @@
 			<operator id="R0Scaler.t:$(n)" parameter="@R0.t:$(n)" scaleFactor="0.8" spec="ScaleOperator" weight="3" />
 			<operator id="becomeUninfectiousRateScaler.t:$(n)" parameter="@becomeUninfectiousRate.t:$(n)" scaleFactor="0.9" spec="ScaleOperator" weight="1" scaleAll="true" optimise="false"/>
 			<operator id="samplingScaler.t:$(n)" parameter="@samplingProportion.t:$(n)" scaleFactor="0.9" spec="ScaleOperator" weight="3.0" />
-	
+			<operator id="rhoScaler.t:$(n)" parameter="@rho.t:$(n)" scaleFactor="0.9" spec="ScaleOperator" weight="3.0" />
+
 			<operator id="updownBD.t:$(n)" scaleFactor="0.9" spec="UpDownOperator" weight="3.0">
 				<up idref="R0.t:$(n)"/>
 				<down idref="becomeUninfectiousRate.t:$(n)"/>
@@ -323,12 +341,12 @@
             <operator id='WilsonBalding.t:$(n)' spec='WilsonBalding' weight="3" tree="@Tree.t:$(n)"/>
 
             <operator id="updowntree.t:$(n)" spec="UpDownOperator" scaleFactor=".9" weight="3" up="@Tree.t:$(n)" down="@mutationRate.s:$(n)"/>
-            <operator id='mutationOperator' spec='ScaleOperator' scaleFactor=".75" weight="1" parameter="@mutationRate.s:$(n)"/>
-            <operator id='R0Operator' spec='ScaleOperator' scaleFactor=".85" weight="2" parameter="@R0.t:$(n)"/>
-            <operator id='bsOperator' spec='ScaleOperator' scaleFactor=".9" weight="2" parameter="@becomeUninfectiousRate.t:$(n)" scaleAll="false"/>
-            <operator id='rateMatrixOperator' spec='ScaleOperator' scaleFactor=".75" weight="2" parameter="@rateMatrix.t:$(n)"/>
-            <operator id="updown1" spec="UpDownOperator" scaleFactor=".9" weight="2" up="@R0.t:$(n)" down="@becomeUninfectiousRate.t:$(n)"/>
-            <operator id="updown2" spec="UpDownOperator" scaleFactor=".9" weight="2" up="@rateMatrix.t:$(n)" down="@becomeUninfectiousRate.t:$(n)"/>
+            <operator id='mutationOperator.t:$(n)' spec='ScaleOperator' scaleFactor=".75" weight="1" parameter="@mutationRate.s:$(n)"/>
+            <operator id='R0Operator.t:$(n)' spec='ScaleOperator' scaleFactor=".85" weight="2" parameter="@R0.t:$(n)"/>
+            <operator id='bsOperator.t:$(n)' spec='ScaleOperator' scaleFactor=".9" weight="2" parameter="@becomeUninfectiousRate.t:$(n)" scaleAll="false"/>
+            <operator id='rateMatrixOperator.t:$(n)' spec='ScaleOperator' scaleFactor=".75" weight="2" parameter="@rateMatrix.t:$(n)"/>
+            <operator id="updown1.t:$(n)" spec="UpDownOperator" scaleFactor=".9" weight="2" up="@R0.t:$(n)" down="@becomeUninfectiousRate.t:$(n)"/>
+            <operator id="updown2.t:$(n)" spec="UpDownOperator" scaleFactor=".9" weight="2" up="@rateMatrix.t:$(n)" down="@becomeUninfectiousRate.t:$(n)"/>
 
 
             <!-- Tree log -->
@@ -341,20 +359,18 @@
 			<connect method="beast.app.beauti.SiteModelInputEditor.customConnector"/>
 			<connect method="beast.app.multitypetree.beauti.InitMigrationModelConnector.customConnector"/>
             <connect method="beast.app.beauti.XIncludeDimensionConnector.customConnector"/>
-
-            <connect srcID="typeTraitSetInput.t:$(n)" targetID="typeSet.t:$(n)" inputName="typeTraitSet"/>
+            <connect method="beast.app.beauti.TraitSetInitConnector.customConnector"/>
 
             <connect srcID='Tree.t:$(n)' targetID='state' inputName='stateNode' if='inposterior(Tree.t:$(n))'/>
             <connect srcID='mutationRate.s:$(n)' targetID='state' inputName='stateNode' if='inlikelihood(mutationRate.s:$(n)) and mutationRate.s:$(n)/estimate=true'/>
             <connect srcID='proportionInvariant.s:$(n)' targetID='state' inputName='stateNode' if='inlikelihood(proportionInvariant.s:$(n)) and proportionInvariant.s:$(n)/estimate=true'/>
-            <connect srcID='mutationRate.s:$(n)' targetID='state' inputName='stateNode' if='inlikelihood(mutationRate.s:$(n)) and mutationRate.s:$(n)/estimate=true'/>
             <connect srcID='gammaShape.s:$(n)' targetID='state' inputName='stateNode' if='inlikelihood(gammaShape.s:$(n)) and gammaShape.s:$(n)/estimate=true'/>
             <connect srcID='R0.t:$(n)' targetID='state' inputName='stateNode' if='inposterior(R0.t:$(n)) and R0.t:$(n)/estimate=true'/>
             <connect srcID='becomeUninfectiousRate.t:$(n)' targetID='state' inputName='stateNode' if='inposterior(becomeUninfectiousRate.t:$(n)) and becomeUninfectiousRate.t:$(n)/estimate=true'/>
             <connect srcID='samplingProportion.t:$(n)' targetID='state' inputName='stateNode' if='inposterior(samplingProportion.t:$(n)) and samplingProportion.t:$(n)/estimate=true'/>
             <connect srcID='rateMatrix.t:$(n)' targetID='state' inputName='stateNode' if='inposterior(rateMatrix.t:$(n)) and rateMatrix.t:$(n)/estimate=true'/>
             <connect srcID='geo-frequencies.t:$(n)' targetID='state' inputName='stateNode' if='inposterior(geo-frequencies.t:$(n)) and geo-frequencies.t:$(n)/estimate=true'/>
-            <connect srcID='R0.t:$(n)' targetID='state' inputName='stateNode' if='inposterior(R0.t:$(n)) and R0.t:$(n)/estimate=true'/>
+            <connect srcID='rho.t:$(n)' targetID='state' inputName='stateNode' if='inposterior(rho.t:$(n)) and rho.t:$(n)/estimate=true'/>
 
             <connect srcID='treeLikelihood.$(n)' targetID='likelihood' inputName='distribution' if="isInitializing"/>
             <connect srcID='birthDeathMigration.t:$(n)' targetID='prior' inputName='distribution' if="Tree.t:$(n)/estimate=true"/>
@@ -367,34 +383,34 @@
             <connect srcID='becomeUninfectiousRatePrior.t:$(n)' targetID='prior' inputName='distribution' if='inposterior(becomeUninfectiousRate.t:$(n)) and becomeUninfectiousRate.t:$(n)/estimate=true'/>
             <connect srcID='samplingProportionPrior.t:$(n)' targetID='prior' inputName='distribution' if='inposterior(samplingProportion.t:$(n)) and samplingProportion.t:$(n)/estimate=true'/>
             <connect srcID='rateMatrixPrior.t:$(n)' targetID='prior' inputName='distribution' if='inposterior(rateMatrix.t:$(n)) and rateMatrix.t:$(n)/estimate=true'/>
+            <connect srcID='rhoPrior.t:$(n)' targetID='prior' inputName='distribution' if='inposterior(rho.t:$(n)) and rho.t:$(n)/estimate=true'/>
+            <connect srcID='geo-frequenciesPrior.t:$(n)' targetID='prior' inputName='distribution' if='inposterior(geo-frequencies.t:$(n)) and geo-frequencies.t:$(n)/estimate=true'/>
 
             <connect srcID='proportionInvariantScaler.s:$(n)' targetID='mcmc' inputName='operator' if='inlikelihood(proportionInvariant.s:$(n)) and proportionInvariant.s:$(n)/estimate=true'>Scales proportion of invariant sites parameter of partition $(n)</connect>
             <connect srcID='mutationRateScaler.s:$(n)' targetID='mcmc' inputName='operator' if='nooperator(FixMeanMutationRatesOperator) and inlikelihood(mutationRate.s:$(n)) and mutationRate.s:$(n)/estimate=true'>Scales mutation rate of partition s:$(n)</connect>
             <connect srcID='gammaShapeScaler.s:$(n)' targetID='mcmc' inputName='operator' if='inlikelihood(gammaShape.s:$(n)) and gammaShape.s:$(n)/estimate=true'>Scales gamma shape parameter of partition s:$(n)</connect>
-            <connect srcID='STX.t:$(n)' targetID='mcmc' inputName='operator' if='inposterior(Tree.t:$(n)) and Tree.t:$(n)/estimate=true'/>
-            <connect srcID='TWB.t:$(n)' targetID='mcmc' inputName='operator' if='inposterior(Tree.t:$(n)) and Tree.t:$(n)/estimate=true'/>
-            <connect srcID='NR.t:$(n)' targetID='mcmc' inputName='operator' if='inposterior(Tree.t:$(n)) and Tree.t:$(n)/estimate=true'/>
-            <connect srcID='NSR1.t:$(n)' targetID='mcmc' inputName='operator' if='inposterior(Tree.t:$(n)) and Tree.t:$(n)/estimate=true'/>
-            <connect srcID='NSR2.t:$(n)' targetID='mcmc' inputName='operator' if='inposterior(Tree.t:$(n)) and Tree.t:$(n)/estimate=true'/>
-            <connect srcID='MTU.t:$(n)' targetID='mcmc' inputName='operator' if='inposterior(Tree.t:$(n)) and Tree.t:$(n)/estimate=true'/>
-            <connect srcID='MTTS.t:$(n)' targetID='mcmc' inputName='operator' if='inposterior(Tree.t:$(n)) and Tree.t:$(n)/estimate=true'/>
-            <connect srcID='MTTUpDown.t:$(n)' targetID='mcmc' inputName='operator' if='Tree.t:$(n)/estimate=true'/>
-            <connect srcID='rateMatrix.t:$(n)' targetID='MTTUpDown.t:$(n)' inputName='parameterInverse' if='Tree.t:$(n)/estimate=true and rateMatrix.t:$(n)/estimate=true'/>
+
+            <connect srcID='TreeScaler.t:$(n)' targetID='mcmc' inputName='operator' if='inposterior(Tree.t:$(n)) and Tree.t:$(n)/estimate=true'/>
+            <connect srcID='TreeRootScaler.t:$(n)' targetID='mcmc' inputName='operator' if='inposterior(Tree.t:$(n)) and Tree.t:$(n)/estimate=true'/>
+            <connect srcID='UniformOperator.t:$(n)' targetID='mcmc' inputName='operator' if='inposterior(Tree.t:$(n)) and Tree.t:$(n)/estimate=true'/>
+            <connect srcID='SubtreeSlide.t:$(n)' targetID='mcmc' inputName='operator' if='inposterior(Tree.t:$(n)) and Tree.t:$(n)/estimate=true'/>
+            <connect srcID='Narrow.t:$(n)' targetID='mcmc' inputName='operator' if='inposterior(Tree.t:$(n)) and Tree.t:$(n)/estimate=true'/>
+            <connect srcID='Wide.t:$(n)' targetID='mcmc' inputName='operator' if='inposterior(Tree.t:$(n)) and Tree.t:$(n)/estimate=true'/>
+            <connect srcID='WilsonBalding.t:$(n)' targetID='mcmc' inputName='operator' if='inposterior(Tree.t:$(n)) and Tree.t:$(n)/estimate=true'/>
+            <connect srcID='updowntree.t:$(n)' targetID='mcmc' inputName='operator' if='inposterior(Tree.t:$(n)) and Tree.t:$(n)/estimate=true'/>
 
 			<connect srcID='R0Scaler.t:$(n)' targetID='mcmc' inputName='operator' if='inposterior(R0.t:$(n)) and R0.t:$(n)/estimate=true'/>
 			<connect srcID='becomeUninfectiousRateScaler.t:$(n)' targetID='mcmc' inputName='operator' if='inposterior(becomeUninfectiousRate.t:$(n)) and becomeUninfectiousRate.t:$(n)/estimate=true'/>
 			<connect srcID='samplingScaler.t:$(n)' targetID='mcmc' inputName='operator' if='inposterior(samplingProportion.t:$(n)) and samplingProportion.t:$(n)/estimate=true'/>
 			<connect srcID='rateMatrixScaler.t:$(n)' targetID='mcmc' inputName='operator' if='inposterior(rateMatrix.t:$(n)) and rateMatrix.t:$(n)/estimate=true'/>
 			<connect srcID='geo-frequenciesExchange.t:$(n)' targetID='mcmc' inputName='operator' if='inposterior(geo-frequencies.t:$(n)) and geo-frequencies.t:$(n)/estimate=true'/>
+            <connect srcID='rhoScaler.t:$(n)' targetID='mcmc' inputName='operator' if='inposterior(rho.t:$(n)) and rho.t:$(n)/estimate=true'/>
 
 			<connect srcID='updownBD.t:$(n)' targetID='mcmc' inputName='operator' if='inposterior(R0.t:$(n)) and R0.t:$(n)/estimate=true and inposterior(becomeUninfectiousRate.t:$(n)) and becomeUninfectiousRate.t:$(n)/estimate=true'/>
 			<connect srcID='updownBM.t:$(n)' targetID='mcmc' inputName='operator' if='inposterior(R0.t:$(n)) and R0.t:$(n)/estimate=true and inposterior(rateMatrix.t:$(n)) and rateMatrix.t:$(n)/estimate=true'/>
 			<connect srcID='updownDS.t:$(n)' targetID='mcmc' inputName='operator' if='inposterior(samplingProportion.t:$(n)) and samplingProportion.t:$(n)/estimate=true and inposterior(becomeUninfectiousRate.t:$(n)) and becomeUninfectiousRate.t:$(n)/estimate=true'/>
 
-
             <connect srcID='treelog.t:$(n)' targetID='mcmc' inputName='logger' if='inposterior(Tree.t:$(n)) and Tree.t:$(n)/estimate=true'/>
-            <connect srcID='maptreelog.t:$(n)' targetID='mcmc' inputName='logger' if='inposterior(Tree.t:$(n)) and Tree.t:$(n)/estimate=true'/>
-            <connect srcID='typednodetreelog.t:$(n)' targetID='mcmc' inputName='logger' if='inposterior(Tree.t:$(n)) and Tree.t:$(n)/estimate=true'/>
 
             <connect srcID='treeLikelihood.$(n)' targetID='tracelog' inputName='log' if='inlikelihood(treeLikelihood.$(n))'/>
             <connect srcID='TreeHeight.t:$(n)' targetID='tracelog' inputName='log' if='inposterior(Tree.t:$(n))'/>
@@ -409,7 +425,7 @@
             <connect srcID='totalChangecounts.t:$(n)' targetID='tracelog' inputName='log' if='inposterior(Tree.t:$(n)) and Tree.t:$(n)/estimate=true'/>
             <connect srcID='nodeTypeCounts.t:$(n)' targetID='tracelog' inputName='log' if='inposterior(Tree.t:$(n)) and Tree.t:$(n)/estimate=true'/>
             <connect srcID='rootTypeLogger.t:$(n)' targetID='tracelog' inputName='log' if='inposterior(Tree.t:$(n)) and Tree.t:$(n)/estimate=true'/>
-            <plate var='p' range='R0,samplingProportion,becomeUninfectiousRate,rateMatrix,geo-frequencies'>
+            <plate var='p' range='R0,samplingProportion,becomeUninfectiousRate,rateMatrix,geo-frequencies,rho'>
                     <connect srcID='$(p).t:$(n)' targetID='tracelog' inputName='log' if='inposterior(birthDeathMigration.t:$(n)) and $(p).t:$(n)/estimate=true'/>
             </plate>
 

--- a/templates/MultiTypeBirthDeathUncoloured.xml
+++ b/templates/MultiTypeBirthDeathUncoloured.xml
@@ -1,0 +1,449 @@
+<beast version='2.0'
+    namespace='beast.app.beauti
+    :beast.core
+    :beast.evolution.branchratemodel
+    :beast.evolution.speciation
+    :beast.evolution.tree.coalescent
+    :beast.core.util
+    :beast.evolution.nuc
+    :beast.evolution.operators
+    :beast.evolution.sitemodel
+    :beast.evolution.substitutionmodel
+    :beast.evolution.likelihood
+    :beast.evolution
+    :beast.math.distributions
+    :multitypetree.operators
+    :multitypetree.distributions'
+    templateinfo='template for multi-type birth-death analyses with tip-typed trees'>
+
+       <map name='connect' reserved='true'>beast.app.beauti.BeautiConnector</map>
+       <map name='subtemplate' reserved='true'>beast.app.beauti.BeautiSubTemplate</map>
+       <map name='Uniform'>beast.math.distributions.Uniform</map>
+       <map name='Normal'>beast.math.distributions.Normal</map>
+       <map name='OneOnX'>beast.math.distributions.OneOnX</map>
+       <map name='LogNormal'>beast.math.distributions.LogNormalDistributionModel</map>
+       <map name='Exponential'>beast.math.distributions.Exponential</map>
+       <map name='Gamma'>beast.math.distributions.Gamma</map>
+       <map name='Beta'>beast.math.distributions.Beta</map>
+       <map name='LaplaceDistribution'>beast.math.distributions.LaplaceDistribution</map>
+       <map name='InverseGamma'>beast.math.distributions.InverseGamma</map>
+       <map name='prior'>beast.math.distributions.Prior</map>
+
+       <beauticonfig spec='BeautiConfig'
+           inputLabelMap='beast.core.MCMC.operator=Operators,
+                          beast.core.MCMC.logger=Loggers,
+                          beast.evolution.sitemodel.SiteModel.mutationRate =Substitution Rate'
+           inlinePlugins = 'beast.core.MCMC.distribution,
+                            beast.evolution.sitemodel.SiteModel.substModel,
+                            beast.evolution.tree.coalescent.ExponentialGrowth,
+                            beast.evolution.tree.coalescent.ConstantPopulation,
+                            beast.evolution.tree.coalescent.Coalescent,
+                            beast.core.State.stateNode,
+                            beast.evolution.tree.MultiTypeTree.migrationModel'
+           collapsedPlugins = 'beast.core.MCMC.logger'
+           suppressPlugins = 'beast.core.MCMC.operator,
+                              beast.core.MCMC.operatorschedule,
+                              beast.evolution.tree.coalescent.Coalescent.treeIntervals,
+                              beast.evolution.tree.coalescent.Coalescent.tree,
+                              beast.core.MCMC.state,
+                              beast.core.MCMC.distribution,
+                              beast.core.MCMC.init,
+                              beast.evolution.speciation.BirthDeathGernhard08Model.treeIntervals,
+                              beast.evolution.speciation.BirthDeathGernhard08Model.tree,
+                              beast.evolution.speciation.BirthDeathGernhard08Model.sampleProbability,
+                              beast.evolution.speciation.YuleModel.treeIntervals,
+                              beast.evolution.speciation.YuleModel.useTipDates,
+                              beast.evolution.speciation.YuleModel.tree,
+                              beast.evolution.tree.Tree,
+                              beast.evolution.tree.Tree.trait,
+                              beast.evolution.tree.Tree.taxa,
+                              beast.evolution.tree.Tree.taxonset,
+                              beast.evolution.tree.RandomTree.trait,
+                              beast.evolution.tree.RandomTree.initial,
+                              beast.evolution.tree.RandomTree.taxa,
+                              beast.evolution.tree.RandomTree.taxonset,
+                              beast.evolution.tree.RandomTree.estimate,
+                              beast.util.TreeParser.initial,
+                              beast.util.TreeParser.taxa,
+                              beast.util.TreeParser.taxonset,
+                              beast.util.TreeParser.trait,
+                              beast.util.TreeParser.estimate,
+                              beast.util.ClusterTree.initial,
+                              beast.util.ClusterTree.taxa,
+                              beast.util.ClusterTree.taxonset,
+                              beast.util.ClusterTree.trait,
+                              beast.util.ClusterTree.estimate,
+                              beast.evolution.substitutionmodel.WAG.rates,
+                              beast.evolution.substitutionmodel.WAG.frequencies,
+                              beast.evolution.substitutionmodel.JTT.rates,
+                              beast.evolution.substitutionmodel.JTT.frequencies,
+                              beast.evolution.substitutionmodel.Blosum62.rates,
+                              beast.evolution.substitutionmodel.Blosum62.frequencies,
+                              beast.evolution.substitutionmodel.Dayhoff.rates,
+                              beast.evolution.substitutionmodel.Dayhoff.frequencies,
+                              beast.evolution.substitutionmodel.CPREV.rates,
+                              beast.evolution.substitutionmodel.CPREV.frequencies,
+                              beast.evolution.substitutionmodel.MTREV.rates,
+                              beast.evolution.substitutionmodel.MTREV.frequencies,
+                              beast.evolution.substitutionmodel.GTR.rates,
+                              beast.evolution.substitutionmodel.JukesCantor.frequencies,
+                              beast.math.distributions.Prior.x,
+                              beast.math.distributions.MRCAPrior.tree,
+                              beast.math.distributions.MRCAPrior.monophyletic,
+                              beast.math.distributions.MRCAPrior.taxonset,
+                              beast.evolution.branchratemodel.UCRelaxedClockModel.tree,
+                              beast.evolution.branchratemodel.UCRelaxedClockModel.rateCategories,
+                              beast.evolution.branchratemodel.UCRelaxedClockModel.distr,
+                              beast.evolution.branchratemodel.RandomLocalClockModel.tree,
+                              beast.evolution.branchratemodel.RandomLocalClockModel.meanRate,
+                              beast.evolution.branchratemodel.RandomLocalClockModel.indicators,
+                              beast.evolution.operators.ScaleOperator.indicator,
+                              beast.core.Operator.weight,
+                              beast.core.Logger.model,
+                              beast.evolution.tree.coalescent.BayesianSkyline.treeIntervals,
+                              beast.evolution.tree.coalescent.BayesianSkyline.groupSizes,
+                              beast.evolution.tree.coalescent.BayesianSkyline.popSizes,
+                              beast.evolution.speciation.YuleModel.originHeight,
+                              multitypetree.distributions.StructuredCoalescentTreeDensity.multiTypeTree,
+							beast.evolution.speciation.BirthDeathMigrationModel.treeIntervals,
+							beast.evolution.speciation.BirthDeathMigrationModel.tree,
+							beast.evolution.speciation.BirthDeathMigrationModel.useTipDates,
+							beast.evolution.speciation.BirthDeathMigrationModel.maxEvaluations,
+							beast.evolution.speciation.BirthDeathMigrationModel.checkRho,
+							beast.evolution.speciation.BirthDeathMigrationModel.origin,
+							beast.evolution.speciation.BirthDeathMigrationModel.originBranch,
+							beast.evolution.speciation.BirthDeathMigrationModel.originIsRootEdge,
+							beast.evolution.speciation.BirthDeathMigrationModel.tolerance,
+							beast.evolution.speciation.BirthDeathMigrationModel.migChangeTimes,
+							beast.evolution.speciation.BirthDeathMigrationModel.birthRateChangeTimes,
+							beast.evolution.speciation.BirthDeathMigrationModel.birthRateAmongDemesChangeTimes,
+							beast.evolution.speciation.BirthDeathMigrationModel.samplingRateChangeTimes,
+							beast.evolution.speciation.BirthDeathMigrationModel.deathRateChangeTimes,
+							beast.evolution.speciation.BirthDeathMigrationModel.removalProbabilityChangeTimes,
+							beast.evolution.speciation.BirthDeathMigrationModel.intervalTimes,
+							beast.evolution.speciation.BirthDeathMigrationModel.migTimesRelative,
+							beast.evolution.speciation.BirthDeathMigrationModel.birthRateTimesRelative,
+							beast.evolution.speciation.BirthDeathMigrationModel.birthRateAmongDemesTimesRelative,
+							beast.evolution.speciation.BirthDeathMigrationModel.deathRateTimesRelative,
+							beast.evolution.speciation.BirthDeathMigrationModel.samplingRateTimesRelative,
+							beast.evolution.speciation.BirthDeathMigrationModel.rhoSamplingTimes,
+							beast.evolution.speciation.BirthDeathMigrationModel.coupledR0Changes,
+							beast.evolution.speciation.BirthDeathMigrationModel.removalAffectsSamplingProportion,
+							beast.evolution.speciation.BirthDeathMigrationModel.removalProbability,
+							beast.evolution.speciation.BirthDeathMigrationModel.adjustTimes,
+							beast.evolution.speciation.BirthDeathMigrationModel.useRK,
+							beast.evolution.speciation.BirthDeathMigrationModel.adjustTimes,
+							beast.evolution.speciation.BirthDeathMigrationModel.rho,
+							beast.evolution.speciation.BirthDeathMigrationModel.contemp,
+							beast.evolution.speciation.BirthDeathMigrationModel.birthRate,
+							beast.evolution.speciation.BirthDeathMigrationModel.birthRateAmongDemes,
+							beast.evolution.speciation.BirthDeathMigrationModel.R0AmongDemes,
+							beast.evolution.speciation.BirthDeathMigrationModel.deathRate,
+							beast.evolution.speciation.BirthDeathMigrationModel.samplingRate,
+							beast.evolution.speciation.BirthDeathMigrationModel.R0,
+							beast.evolution.speciation.BirthDeathMigrationModel.samplingProportion,
+							beast.evolution.speciation.BirthDeathMigrationModel.becomeUninfectiousRate,
+							beast.evolution.speciation.BirthDeathMigrationModel.migrationMatrix,
+							beast.evolution.speciation.BirthDeathMigrationModel.frequencies,
+							beast.evolution.speciation.BirthDeathMigrationModel.reverseTimeArrays,
+							beast.evolution.speciation.BirthDeathMigrationModel.stateNumber
+							'>
+                                      
+        <panel spec='BeautiPanelConfig' panelname="Partitions" tiptext="Data Partitions"
+            path='distribution/distribution[id="likelihood"]/distribution/data'
+            hasPartitions="none" icon='2220.png.x' forceExpansion='FALSE'
+            type='beast.evolution.alignment.Alignment'
+            />
+
+		<panel spec='BeautiPanelConfig' panelname="Tip Dates" tiptext="Specify times at which taxa were sampled"
+            path='tree'
+            hasPartitions="Tree" icon='2.png.x' forceExpansion='TRUE'
+            isVisible='true'
+        />
+
+		<panel spec='BeautiPanelConfig' panelname="Tip Locations" tiptext="Specify locations from which taxa were sampled"
+            path='tree/typeTrait'
+            hasPartitions="Tree" icon='2.png.x' forceExpansion='TRUE'
+            isVisible='true'
+        />
+
+        <panel spec='BeautiPanelConfig' panelname="Site Model" tiptext="Site model and substitution model specifications"
+            path='siteModel'
+            hasPartitions="SiteModel" icon='3.png.x' forceExpansion='TRUE'
+            />
+
+        <panel spec='BeautiPanelConfig' panelname="Clock Model" tiptext="Clock model"
+            path='branchRateModel'
+            hasPartitions="ClockModel" icon='4.png.x' forceExpansion='TRUE'
+        />
+
+        <panel spec='BeautiPanelConfig' panelname="Priors" tiptext="Other priors"
+            path='distribution/distribution[id="prior"]/distribution'
+            hasPartitions="none" icon='7.png.x' forceExpansion='TRUE_START_COLLAPSED'
+            type='beast.core.Distribution'
+        />
+
+        <panel spec='BeautiPanelConfig' panelname="Operators" tiptext="MCMC Operator details"
+            path='operator'
+            hasPartitions="none" icon='8.png.x' forceExpansion='TRUE_START_COLLAPSED'
+            isVisible='false' buttonStatus='ADD_ONLY'
+        />
+
+		<panel spec='BeautiPanelConfig' panelname="MCMC" tiptext="MCMC parameters"
+            path=''
+            hasPartitions="none" icon='9.png.x' forceExpansion='TRUE'
+            />
+
+		<alignmentProvider id="Add Alignment" spec='BeautiAlignmentProvider' template='@StandardPartitionTemplate'/>
+
+        <partitiontemplate id='StandardPartitionTemplate' spec='beast.app.beauti.BeautiSubTemplate' class='beast.evolution.likelihood.TreeLikelihood' mainid='mcmc'>
+<![CDATA[
+
+            <!-- Multi type tree -->
+
+            <plugin spec='beast.evolution.tree.RandomTree' id='Tree.t:$(n)' estimate='true'>
+                <taxa idref='data'/>
+                <populationModel id='ConstantPopulation0.t:$(n)' spec='ConstantPopulation'>
+            		<popSize id='randomPopSize.t:$(n)' spec='parameter.RealParameter' value='1'/>
+	            </populationModel>
+            </plugin>
+
+            <!-- Tree likelihood -->
+
+            <plugin spec='TreeLikelihood' id="treeLikelihood.$(n)">
+                <data idref="data"/>
+                <tree idref="Tree.t:$(n)"/>
+                <siteModel spec='SiteModel' id="SiteModel.s:$(n)" gammaCategoryCount='0'>
+                    <proportionInvariant spec='parameter.RealParameter' id='proportionInvariant.s:$(n)' value='0.0' lower='0' upper='1' estimate='false'/>
+                    <mutationRate spec='parameter.RealParameter' id='mutationRate.s:$(n)' value='1.0' estimate='false'/>
+                    <shape spec='parameter.RealParameter' id='gammaShape.s:$(n)' value='1.0' estimate='false'/>
+                </siteModel>
+               <branchRateModel spec='StrictClockModel' id='StrictClock.c:$(n)'>
+                    <clock.rate id='clockRate.c:$(n)' spec='parameter.RealParameter' value='1.0' estimate='false'/>
+                </branchRateModel>
+            </plugin>
+
+            <!-- Tree prior -->
+
+            <distribution spec="beast.evolution.speciation.BirthDeathMigrationModelUncoloured" id="birthDeathMigration.t:$(n)" tree="@tree"
+				  stateNumber="2" conditionOnSurvival="true">
+                <migrationMatrix spec="RealParameter" id="rateMatrix.t:$(n)" value="0.01" dimension="2" lower="0" upper="100"/>
+                <parameter name="frequencies" id="geo-frequencies.t:$(n)" value=".5 .5" lower="0." upper="1." dimension="2"/>
+                <parameter name="R0" id="R0.t:$(n)" lower="0" dimension="2" value="3"/>
+                <parameter name="becomeUninfectiousRate" id="becomeUninfectiousRate.t:$(n)" value=".1" lower="0" dimension="2" />
+                <parameter name="samplingProportion" id="samplingProportion.t:$(n)" value="0.05 0.15" lower="0" dimension="2"  upper="1."/>
+            </distribution>
+
+
+            <!-- Parameter priors -->
+
+            <prior id='ClockPrior.c:$(n)' x='@clockRate.c:$(n)'>
+                <distr spec="beast.math.distributions.Uniform" upper='Infinity'/>
+            </prior>
+
+            <prior id='MutationRatePrior.s:$(n)' x='@mutationRate.s:$(n)'>
+                <distr spec="beast.math.distributions.OneOnX"/>
+            </prior>
+
+            <prior id='GammaShapePrior.s:$(n)' x='@gammaShape.s:$(n)'>
+                <distr spec="beast.math.distributions.Exponential" mean='1'/>
+            </prior>
+
+            <prior id='PropInvariantPrior.s:$(n)' x='@proportionInvariant.s:$(n)'>
+                <distr spec="beast.math.distributions.Uniform" lower='0' upper='1'/>
+            </prior>
+
+			<distribution id="becomeUninfectiousRatePrior.t:$(n)" spec="beast.math.distributions.Prior" x="@becomeUninfectiousRate.t:$(n)">
+				<distr spec='beast.math.distributions.LogNormalDistributionModel' offset="0.0" meanInRealSpace="false">
+					<parameter name="M" value="0." estimate="false"/> 
+					<parameter name="S" value="1." estimate="false"/> 
+				</distr>	
+			</distribution>
+			
+			<distribution id="RPrior.t:$(n)" spec="beast.math.distributions.Prior" x="@R0.t:$(n)">
+				<distr spec='beast.math.distributions.LogNormalDistributionModel' offset="0.0" meanInRealSpace="false">
+					<parameter name="M" value="0." estimate="false"/> 
+					<parameter name="S" value="1." estimate="false"/> 
+				</distr>	
+			</distribution>
+ 
+			<distribution spec='multitypetree.distributions.ExcludablePrior' id="samplingProportionPrior.t:$(n)" x="@samplingProportion.t:$(n)">
+			<xInclude spec='parameter.BooleanParameter' id="samplingProportionXInclude.t:$(n)" value="true true"/>
+				<distr spec="beast.math.distributions.Beta" offset="0.">
+					<parameter name="alpha" value="1." estimate="false"/> 
+					<parameter name="beta" value="1." estimate="false"/> 
+				</distr>	
+			</distribution>
+
+            <prior id='rateMatrixPrior.t:$(n)' x='@rateMatrix.t:$(n)'>
+				<distr spec='beast.math.distributions.Exponential'>
+					<parameter name="mean" value="1." estimate="false"/> 
+				</distr>	
+            </prior>
+
+            <!-- Parameter operators -->
+            
+            <operator id='proportionInvariantScaler.s:$(n)' spec='ScaleOperator' scaleFactor="0.5" weight="0.1" parameter="@proportionInvariant.s:$(n)"/>
+            <operator id='mutationRateScaler.s:$(n)' spec='ScaleOperator' scaleFactor="0.5" weight="0.1" parameter="@mutationRate.s:$(n)"/>
+            <operator id='gammaShapeScaler.s:$(n)' spec='ScaleOperator' scaleFactor="0.5" weight="0.1" parameter="@gammaShape.s:$(n)"/>
+
+			<operator id="R0Scaler.t:$(n)" parameter="@R0.t:$(n)" scaleFactor="0.8" spec="ScaleOperator" weight="3" />
+			<operator id="becomeUninfectiousRateScaler.t:$(n)" parameter="@becomeUninfectiousRate.t:$(n)" scaleFactor="0.9" spec="ScaleOperator" weight="1" scaleAll="true" optimise="false"/>
+			<operator id="samplingScaler.t:$(n)" parameter="@samplingProportion.t:$(n)" scaleFactor="0.9" spec="ScaleOperator" weight="3.0" />
+	
+			<operator id="updownBD.t:$(n)" scaleFactor="0.9" spec="UpDownOperator" weight="3.0">
+				<up idref="R0.t:$(n)"/>
+				<down idref="becomeUninfectiousRate.t:$(n)"/>
+			</operator>
+	
+			<operator id="updownBM.t:$(n)" scaleFactor="0.9" spec="UpDownOperator" weight="3.0">
+				<up idref="R0.t:$(n)"/>
+				<down idref="rateMatrix.t:$(n)"/>
+			</operator>
+	
+			<operator id="updownDS.t:$(n)" scaleFactor="0.9" spec="UpDownOperator" weight="3.0">
+				<up idref="samplingProportion.t:$(n)"/>
+				<down idref="becomeUninfectiousRate.t:$(n)"/>
+			</operator>
+	
+  
+			<operator id="geo-frequenciesExchange.t:$(n)" spec="DeltaExchangeOperator" parameter="@geo-frequencies.t:$(n)" delta="0.1" weight=".1"/>
+
+            <operator id='rateMatrixScaler.t:$(n)' spec='ScaleOperator' scaleFactor="0.8" weight="1" parameter="@rateMatrix.t:$(n)"/>
+
+            <!-- Tree operators -->
+
+            <operator id="treeScaler" scaleFactor="0.75" spec="ScaleOperator" tree="@Tree.t:$(n)" weight="3.0"/>
+            <operator id="treeRootScaler" rootOnly="true" scaleFactor="0.75" spec="ScaleOperator" tree="@Tree.t:$(n)" weight="3.0"/>
+            <operator id="narrow" spec="Exchange" tree="@Tree.t:(n)" weight="15.0"/>
+            <operator id="UniformOperator" spec="Uniform" tree="@Tree.t:(n)" weight="30.0"/>
+            <operator id="SubtreeSlide" spec="SubtreeSlide" tree="@Tree.t:(n)" weight="15.0"/>
+            <operator id="wide" isNarrow="false" spec="Exchange" tree="@Tree.t:(n)" weight="3.0"/>
+            <operator id="WilsonBalding" spec="WilsonBalding" tree="@Tree.t:(n)" weight="3.0"/>
+            <operator id="updowntree" spec="UpDownOperator" scaleFactor=".9" weight="3" up="@Tree.t:(n)" down="@mutationRate"/>
+            <operator id='mutationOperator' spec='ScaleOperator' scaleFactor=".75" weight="1" parameter="@mutationRate.t:$(n)"/>
+            <operator id='R0Operator' spec='ScaleOperator' scaleFactor=".85" weight="2" parameter="@R0.t:$(n)"/>
+            <operator id='bsOperator' spec='ScaleOperator' scaleFactor=".9" weight="2" parameter="@becomeUninfectiousRate.t:$(n)" scaleAll="false"/>
+            <operator id='rateMatrixOperator' spec='ScaleOperator' scaleFactor=".75" weight="2" parameter="@rateMatrix.t:$(n)"/>
+            <operator id="updown1" spec="UpDownOperator" scaleFactor=".9" weight="2" up="@R0" down="@becomeUninfectiousRate.t:$(n)"/>
+            <operator id="updown2" spec="UpDownOperator" scaleFactor=".9" weight="2" up="@rateMatrix" down="@becomeUninfectiousRate.t:$(n)"/>
+
+
+            <!-- Tree log -->
+            <logger id="treelog.t:$(n)" logEvery="10000" fileName="$(filebase).$(tree).trees" mode="tree" log="@Tree.t:$(n)"/>
+
+            <!-- Trace log elements -->
+
+]]>
+
+			<connect method="beast.app.beauti.SiteModelInputEditor.customConnector"/>
+			<connect method="beast.app.multitypetree.beauti.InitMigrationModelConnector.customConnector"/>
+            <connect method="beast.app.beauti.XIncludeDimensionConnector.customConnector"/>
+
+            <connect srcID="typeTraitSetInput.t:$(n)" targetID="typeSet.t:$(n)" inputName="typeTraitSet"/>
+
+            <connect srcID='Tree.t:$(n)' targetID='state' inputName='stateNode' if='inposterior(Tree.t:$(n))'/>
+            <connect srcID='mutationRate.s:$(n)' targetID='state' inputName='stateNode' if='inlikelihood(mutationRate.s:$(n)) and mutationRate.s:$(n)/estimate=true'/>
+            <connect srcID='proportionInvariant.s:$(n)' targetID='state' inputName='stateNode' if='inlikelihood(proportionInvariant.s:$(n)) and proportionInvariant.s:$(n)/estimate=true'/>
+            <connect srcID='mutationRate.s:$(n)' targetID='state' inputName='stateNode' if='inlikelihood(mutationRate.s:$(n)) and mutationRate.s:$(n)/estimate=true'/>
+            <connect srcID='gammaShape.s:$(n)' targetID='state' inputName='stateNode' if='inlikelihood(gammaShape.s:$(n)) and gammaShape.s:$(n)/estimate=true'/>
+            <connect srcID='R0.t:$(n)' targetID='state' inputName='stateNode' if='inposterior(R0.t:$(n)) and R0.t:$(n)/estimate=true'/>
+            <connect srcID='becomeUninfectiousRate.t:$(n)' targetID='state' inputName='stateNode' if='inposterior(becomeUninfectiousRate.t:$(n)) and becomeUninfectiousRate.t:$(n)/estimate=true'/>
+            <connect srcID='samplingProportion.t:$(n)' targetID='state' inputName='stateNode' if='inposterior(samplingProportion.t:$(n)) and samplingProportion.t:$(n)/estimate=true'/>
+            <connect srcID='rateMatrix.t:$(n)' targetID='state' inputName='stateNode' if='inposterior(rateMatrix.t:$(n)) and rateMatrix.t:$(n)/estimate=true'/>
+            <connect srcID='geo-frequencies.t:$(n)' targetID='state' inputName='stateNode' if='inposterior(geo-frequencies.t:$(n)) and geo-frequencies.t:$(n)/estimate=true'/>
+            <connect srcID='R0.t:$(n)' targetID='state' inputName='stateNode' if='inposterior(R0.t:$(n)) and R0.t:$(n)/estimate=true'/>
+
+            <connect srcID='treeLikelihood.$(n)' targetID='likelihood' inputName='distribution' if="isInitializing"/>
+            <connect srcID='birthDeathMigration.t:$(n)' targetID='prior' inputName='distribution' if="Tree.t:$(n)/estimate=true"/>
+            <connect srcID='ClockPrior.c:$(n)'                targetID='prior' inputName='distribution' if='inlikelihood(clockRate.c:$(n)) and clockRate.c:$(n)/estimate=true'/>
+            <connect srcID='MutationRatePrior.s:$(n)'         targetID='prior' inputName='distribution' if='nooperator(FixMeanMutationRatesOperator) and inlikelihood(mutationRate.s:$(n)) and mutationRate.s:$(n)/estimate=true'/>
+            <connect srcID='GammaShapePrior.s:$(n)'           targetID='prior' inputName='distribution' if='inlikelihood(gammaShape.s:$(n)) and gammaShape.s:$(n)/estimate=true'>Prior on gamma shape for partition s:$(n)</connect>
+            <connect srcID='PropInvariantPrior.s:$(n)'        targetID='prior' inputName='distribution' if='inlikelihood(proportionInvariant.s:$(n)) and proportionInvariant.s:$(n)/estimate=true'>Prior on proportion invariant for partition s:$(n)</connect>
+
+            <connect srcID='RPrior.t:$(n)' targetID='prior' inputName='distribution' if='inposterior(R0.t:$(n)) and R0.t:$(n)/estimate=true'/>
+            <connect srcID='becomeUninfectiousRatePrior.t:$(n)' targetID='prior' inputName='distribution' if='inposterior(becomeUninfectiousRate.t:$(n)) and becomeUninfectiousRate.t:$(n)/estimate=true'/>
+            <connect srcID='samplingProportionPrior.t:$(n)' targetID='prior' inputName='distribution' if='inposterior(samplingProportion.t:$(n)) and samplingProportion.t:$(n)/estimate=true'/>
+            <connect srcID='rateMatrixPrior.t:$(n)' targetID='prior' inputName='distribution' if='inposterior(rateMatrix.t:$(n)) and rateMatrix.t:$(n)/estimate=true'/>
+
+            <connect srcID='proportionInvariantScaler.s:$(n)' targetID='mcmc' inputName='operator' if='inlikelihood(proportionInvariant.s:$(n)) and proportionInvariant.s:$(n)/estimate=true'>Scales proportion of invariant sites parameter of partition $(n)</connect>
+            <connect srcID='mutationRateScaler.s:$(n)' targetID='mcmc' inputName='operator' if='nooperator(FixMeanMutationRatesOperator) and inlikelihood(mutationRate.s:$(n)) and mutationRate.s:$(n)/estimate=true'>Scales mutation rate of partition s:$(n)</connect>
+            <connect srcID='gammaShapeScaler.s:$(n)' targetID='mcmc' inputName='operator' if='inlikelihood(gammaShape.s:$(n)) and gammaShape.s:$(n)/estimate=true'>Scales gamma shape parameter of partition s:$(n)</connect>
+            <connect srcID='STX.t:$(n)' targetID='mcmc' inputName='operator' if='inposterior(Tree.t:$(n)) and Tree.t:$(n)/estimate=true'/>
+            <connect srcID='TWB.t:$(n)' targetID='mcmc' inputName='operator' if='inposterior(Tree.t:$(n)) and Tree.t:$(n)/estimate=true'/>
+            <connect srcID='NR.t:$(n)' targetID='mcmc' inputName='operator' if='inposterior(Tree.t:$(n)) and Tree.t:$(n)/estimate=true'/>
+            <connect srcID='NSR1.t:$(n)' targetID='mcmc' inputName='operator' if='inposterior(Tree.t:$(n)) and Tree.t:$(n)/estimate=true'/>
+            <connect srcID='NSR2.t:$(n)' targetID='mcmc' inputName='operator' if='inposterior(Tree.t:$(n)) and Tree.t:$(n)/estimate=true'/>
+            <connect srcID='MTU.t:$(n)' targetID='mcmc' inputName='operator' if='inposterior(Tree.t:$(n)) and Tree.t:$(n)/estimate=true'/>
+            <connect srcID='MTTS.t:$(n)' targetID='mcmc' inputName='operator' if='inposterior(Tree.t:$(n)) and Tree.t:$(n)/estimate=true'/>
+            <connect srcID='MTTUpDown.t:$(n)' targetID='mcmc' inputName='operator' if='Tree.t:$(n)/estimate=true'/>
+            <connect srcID='rateMatrix.t:$(n)' targetID='MTTUpDown.t:$(n)' inputName='parameterInverse' if='Tree.t:$(n)/estimate=true and rateMatrix.t:$(n)/estimate=true'/>
+
+			<connect srcID='R0Scaler.t:$(n)' targetID='mcmc' inputName='operator' if='inposterior(R0.t:$(n)) and R0.t:$(n)/estimate=true'/>
+			<connect srcID='becomeUninfectiousRateScaler.t:$(n)' targetID='mcmc' inputName='operator' if='inposterior(becomeUninfectiousRate.t:$(n)) and becomeUninfectiousRate.t:$(n)/estimate=true'/>
+			<connect srcID='samplingScaler.t:$(n)' targetID='mcmc' inputName='operator' if='inposterior(samplingProportion.t:$(n)) and samplingProportion.t:$(n)/estimate=true'/>
+			<connect srcID='rateMatrixScaler.t:$(n)' targetID='mcmc' inputName='operator' if='inposterior(rateMatrix.t:$(n)) and rateMatrix.t:$(n)/estimate=true'/>
+			<connect srcID='geo-frequenciesExchange.t:$(n)' targetID='mcmc' inputName='operator' if='inposterior(geo-frequencies.t:$(n)) and geo-frequencies.t:$(n)/estimate=true'/>
+
+			<connect srcID='updownBD.t:$(n)' targetID='mcmc' inputName='operator' if='inposterior(R0.t:$(n)) and R0.t:$(n)/estimate=true and inposterior(becomeUninfectiousRate.t:$(n)) and becomeUninfectiousRate.t:$(n)/estimate=true'/>
+			<connect srcID='updownBM.t:$(n)' targetID='mcmc' inputName='operator' if='inposterior(R0.t:$(n)) and R0.t:$(n)/estimate=true and inposterior(rateMatrix.t:$(n)) and rateMatrix.t:$(n)/estimate=true'/>
+			<connect srcID='updownDS.t:$(n)' targetID='mcmc' inputName='operator' if='inposterior(samplingProportion.t:$(n)) and samplingProportion.t:$(n)/estimate=true and inposterior(becomeUninfectiousRate.t:$(n)) and becomeUninfectiousRate.t:$(n)/estimate=true'/>
+
+
+            <connect srcID='treelog.t:$(n)' targetID='mcmc' inputName='logger' if='inposterior(Tree.t:$(n)) and Tree.t:$(n)/estimate=true'/>
+            <connect srcID='maptreelog.t:$(n)' targetID='mcmc' inputName='logger' if='inposterior(Tree.t:$(n)) and Tree.t:$(n)/estimate=true'/>
+            <connect srcID='typednodetreelog.t:$(n)' targetID='mcmc' inputName='logger' if='inposterior(Tree.t:$(n)) and Tree.t:$(n)/estimate=true'/>
+
+            <connect srcID='treeLikelihood.$(n)' targetID='tracelog' inputName='log' if='inlikelihood(treeLikelihood.$(n))'/>
+            <connect srcID='TreeHeight.t:$(n)' targetID='tracelog' inputName='log' if='inposterior(Tree.t:$(n))'/>
+            <connect srcID='proportionInvariant.s:$(n)' targetID='tracelog' inputName='log' if='inposterior(proportionInvariant.s:$(n)) and proportionInvariant.s:$(n)/estimate=true'/>
+            <connect srcID='mutationRate.s:$(n)' targetID='tracelog' inputName='log' if='inlikelihood(mutationRate.s:$(n)) and mutationRate.s:$(n)/estimate=true'/>
+            <connect srcID='gammaShape.s:$(n)' targetID='tracelog' inputName='log' if='inlikelihood(gammaShape.s:$(n)) and gammaShape.s:$(n)/estimate=true'/>
+            <connect srcID='clockRate.c:$(n)' targetID='tracelog' inputName='log' if='inlikelihood(clockRate.c:$(n)) and clockRate.c:$(n)/estimate=true'/>
+
+            <connect srcID='treeHeight.t:$(n)' targetID='tracelog' inputName='log' if='inposterior(Tree.t:$(n)) and Tree.t:$(n)/estimate=true'/>
+            <connect srcID='treeLength.t:$(n)' targetID='tracelog' inputName='log' if='inposterior(Tree.t:$(n)) and Tree.t:$(n)/estimate=true'/>
+            <connect srcID='changeCounts.t:$(n)' targetID='tracelog' inputName='log' if='inposterior(Tree.t:$(n)) and Tree.t:$(n)/estimate=true'/>
+            <connect srcID='totalChangecounts.t:$(n)' targetID='tracelog' inputName='log' if='inposterior(Tree.t:$(n)) and Tree.t:$(n)/estimate=true'/>
+            <connect srcID='nodeTypeCounts.t:$(n)' targetID='tracelog' inputName='log' if='inposterior(Tree.t:$(n)) and Tree.t:$(n)/estimate=true'/>
+            <connect srcID='rootTypeLogger.t:$(n)' targetID='tracelog' inputName='log' if='inposterior(Tree.t:$(n)) and Tree.t:$(n)/estimate=true'/>
+            <plate var='p' range='R0,samplingProportion,becomeUninfectiousRate,rateMatrix,geo-frequencies'>
+                    <connect srcID='$(p).t:$(n)' targetID='tracelog' inputName='log' if='inposterior(birthDeathMigration.t:$(n)) and $(p).t:$(n)/estimate=true'/>
+            </plate>
+
+        </partitiontemplate>
+
+        <mergepoint id='substModelTemplates'/>
+		<mergepoint id='mttClockModelTemplates'/>
+        <mergepoint id='parametricDistributions'/>
+    </beauticonfig>
+
+
+<!-- framework for main model -->
+
+    <run spec="MCMC" id="mcmc" chainLength="10000000">
+
+        <state storeEvery='5000' id='state'></state>
+
+        <distribution spec="CompoundDistribution" id="posterior">
+            <distribution spec="CompoundDistribution" id="prior"/>
+            <distribution spec="CompoundDistribution" id="likelihood"/>
+        </distribution>
+
+        <logger id='tracelog' logEvery="1000" fileName="$(filebase).log">
+            <log idref="posterior"/>
+            <log idref="likelihood"/>
+            <log idref="prior"/>
+        </logger>
+
+        <logger id='screenlog' logEvery="1000">
+	        <!--model idref='posterior'/-->
+            <log idref="posterior"/>
+      	    <ESS spec='ESS' name='log' arg="@posterior"/>
+            <log idref="likelihood"/>
+            <log idref="prior"/>
+        </logger>
+    </run>
+
+</beast>
+

--- a/templates/MultiTypeBirthDeathUncoloured.xml
+++ b/templates/MultiTypeBirthDeathUncoloured.xml
@@ -225,9 +225,9 @@
 
             <!-- Tree prior -->
 
-            <distribution spec="beast.evolution.speciation.BirthDeathMigrationModelUncoloured" id="birthDeathMigration.t:$(n)" tree="@tree"
+            <distribution spec="beast.evolution.speciation.BirthDeathMigrationModelUncoloured" id="birthDeathMigration.t:$(n)" tree="@Tree.t:$(n)"
 				  stateNumber="2" conditionOnSurvival="true">
-                <migrationMatrix spec="RealParameter" id="rateMatrix.t:$(n)" value="0.01" dimension="2" lower="0" upper="100"/>
+                <migrationMatrix spec="beast.core.parameter.RealParameter" id="rateMatrix.t:$(n)" value="0.01" dimension="2" lower="0" upper="100"/>
                 <parameter name="frequencies" id="geo-frequencies.t:$(n)" value=".5 .5" lower="0." upper="1." dimension="2"/>
                 <parameter name="R0" id="R0.t:$(n)" lower="0" dimension="2" value="3"/>
                 <parameter name="becomeUninfectiousRate" id="becomeUninfectiousRate.t:$(n)" value=".1" lower="0" dimension="2" />
@@ -313,20 +313,22 @@
 
             <!-- Tree operators -->
 
-            <operator id="treeScaler" scaleFactor="0.75" spec="ScaleOperator" tree="@Tree.t:$(n)" weight="3.0"/>
-            <operator id="treeRootScaler" rootOnly="true" scaleFactor="0.75" spec="ScaleOperator" tree="@Tree.t:$(n)" weight="3.0"/>
-            <operator id="narrow" spec="Exchange" tree="@Tree.t:(n)" weight="15.0"/>
-            <operator id="UniformOperator" spec="Uniform" tree="@Tree.t:(n)" weight="30.0"/>
-            <operator id="SubtreeSlide" spec="SubtreeSlide" tree="@Tree.t:(n)" weight="15.0"/>
-            <operator id="wide" isNarrow="false" spec="Exchange" tree="@Tree.t:(n)" weight="3.0"/>
-            <operator id="WilsonBalding" spec="WilsonBalding" tree="@Tree.t:(n)" weight="3.0"/>
-            <operator id="updowntree" spec="UpDownOperator" scaleFactor=".9" weight="3" up="@Tree.t:(n)" down="@mutationRate"/>
-            <operator id='mutationOperator' spec='ScaleOperator' scaleFactor=".75" weight="1" parameter="@mutationRate.t:$(n)"/>
+
+            <operator id='TreeScaler.t:$(n)' spec='ScaleOperator' scaleFactor="0.5" weight="3" tree="@Tree.t:$(n)"/>
+            <operator id='TreeRootScaler.t:$(n)' spec='ScaleOperator' scaleFactor="0.5" weight="3" tree="@Tree.t:$(n)" rootOnly='true'/>
+            <operator id='UniformOperator.t:$(n)' spec='Uniform' weight="30" tree="@Tree.t:$(n)"/>
+            <operator id='SubtreeSlide.t:$(n)' spec='SubtreeSlide' weight="15" gaussian="true" size="1.0" tree="@Tree.t:$(n)"/>
+            <operator id='Narrow.t:$(n)' spec='Exchange' isNarrow='true' weight="15" tree="@Tree.t:$(n)"/>
+            <operator id='Wide.t:$(n)' spec='Exchange' isNarrow='false' weight="3" tree="@Tree.t:$(n)"/>
+            <operator id='WilsonBalding.t:$(n)' spec='WilsonBalding' weight="3" tree="@Tree.t:$(n)"/>
+
+            <operator id="updowntree.t:$(n)" spec="UpDownOperator" scaleFactor=".9" weight="3" up="@Tree.t:$(n)" down="@mutationRate.s:$(n)"/>
+            <operator id='mutationOperator' spec='ScaleOperator' scaleFactor=".75" weight="1" parameter="@mutationRate.s:$(n)"/>
             <operator id='R0Operator' spec='ScaleOperator' scaleFactor=".85" weight="2" parameter="@R0.t:$(n)"/>
             <operator id='bsOperator' spec='ScaleOperator' scaleFactor=".9" weight="2" parameter="@becomeUninfectiousRate.t:$(n)" scaleAll="false"/>
             <operator id='rateMatrixOperator' spec='ScaleOperator' scaleFactor=".75" weight="2" parameter="@rateMatrix.t:$(n)"/>
-            <operator id="updown1" spec="UpDownOperator" scaleFactor=".9" weight="2" up="@R0" down="@becomeUninfectiousRate.t:$(n)"/>
-            <operator id="updown2" spec="UpDownOperator" scaleFactor=".9" weight="2" up="@rateMatrix" down="@becomeUninfectiousRate.t:$(n)"/>
+            <operator id="updown1" spec="UpDownOperator" scaleFactor=".9" weight="2" up="@R0.t:$(n)" down="@becomeUninfectiousRate.t:$(n)"/>
+            <operator id="updown2" spec="UpDownOperator" scaleFactor=".9" weight="2" up="@rateMatrix.t:$(n)" down="@becomeUninfectiousRate.t:$(n)"/>
 
 
             <!-- Tree log -->

--- a/templates/MultiTypeBirthDeathUncoloured.xml
+++ b/templates/MultiTypeBirthDeathUncoloured.xml
@@ -39,7 +39,7 @@
                             beast.evolution.tree.coalescent.ConstantPopulation,
                             beast.evolution.tree.coalescent.Coalescent,
                             beast.core.State.stateNode,
-                            beast.evolution.tree.MultiTypeTree.migrationModel'
+							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.stateNumber'
            collapsedPlugins = 'beast.core.MCMC.logger'
            suppressPlugins = 'beast.core.MCMC.operator,
                               beast.core.MCMC.operatorschedule,
@@ -115,7 +115,6 @@
 							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.migChangeTimes,
 							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.birthRateChangeTimes,
 							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.birthRateAmongDemesChangeTimes,
-							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.samplingRateChangeTimes,
 							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.deathRateChangeTimes,
 							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.removalProbabilityChangeTimes,
 							beast.evolution.speciation.BirthDeathMigrationModelUncoloured.intervalTimes,
@@ -239,7 +238,8 @@
                 <frequencies spec="parameter.RealParameter" id="geo-frequencies.t:$(n)" value=".5 .5" lower="0." upper="1." dimension="2"/>
                 <R0 spec="parameter.RealParameter" id="R0.t:$(n)" lower="0" dimension="2" value="1.5"/>
                 <becomeUninfectiousRate spec="parameter.RealParameter" id="becomeUninfectiousRate.t:$(n)" value="0.1" lower="0" dimension="2" />
-                <samplingProportion spec="parameter.RealParameter" id="samplingProportion.t:$(n)" value="0.05" lower="0" dimension="2"  upper="1."/>
+                <samplingProportion spec="parameter.RealParameter" id="samplingProportion.t:$(n)" value="0.1 0.05 0.1 0.05" lower="0" dimension="4"  upper="1."/>
+                <samplingRateChangeTimes spec="parameter.RealParameter" id="samplingRateChangeTimes.t:$(n)" value="0.0 5.0" estimate="false"/>
                 <rho spec="parameter.RealParameter" id="rho.t:$(n)" value="0.5" dimension="2"/>
             </distribution>
 
@@ -277,7 +277,7 @@
 			</distribution>
  
 			<distribution spec='multitypetree.distributions.ExcludablePrior' id="samplingProportionPrior.t:$(n)" x="@samplingProportion.t:$(n)">
-			<xInclude spec='parameter.BooleanParameter' id="samplingProportionXInclude.t:$(n)" value="true true"/>
+			<xInclude spec='parameter.BooleanParameter' id="samplingProportionXInclude.t:$(n)" value="true true true true"/>
 				<distr spec="beast.math.distributions.Beta" offset="0.">
 					<parameter name="alpha" value="1." estimate="false"/> 
 					<parameter name="beta" value="1." estimate="false"/> 
@@ -432,7 +432,7 @@
         </partitiontemplate>
 
         <mergepoint id='substModelTemplates'/>
-		<mergepoint id='mttClockModelTemplates'/>
+		<mergepoint id='clockModelTemplates'/>
         <mergepoint id='parametricDistributions'/>
     </beauticonfig>
 


### PR DESCRIPTION
These commit add a (very basic) template for tip-typed BDMM analyses.

This offers the same functionality in terms of model specification as the coloured BDMM template, although it's slightly more awkward to use due to a bug in BEAUti's RealParameter input editor.  (Dimensions of these parameters cannot be currently changed directly: only by editing the parameter using the "initial" button next to the corresponding prior can the dimension be changed.)