### PR TITLE
Added class to define TraitSets using general node metadata.

### DIFF
--- a/src/beast/core/util/TipDatesFromTree.java
+++ b/src/beast/core/util/TipDatesFromTree.java
@@ -11,34 +11,19 @@ import beast.util.TreeParser;
  * @author Tim Vaughan <tgvaughan@gmail.com>
  */
 @Description("Traitset for tip dates obtained from input tree")
-public class TipDatesFromTree extends TraitSet{
-
-    public Input<Tree> treeInput = new Input<>("tree", "Tree from which to " +
-            "extract tip dates.", Input.Validate.REQUIRED);
+public class TipDatesFromTree extends TipTypesFromTree {
 
     public TipDatesFromTree() {
-        traitsInput.setRule(Input.Validate.OPTIONAL);
+        super();
         traitNameInput.setRule(Input.Validate.OPTIONAL);
     }
+
 
     @Override
     public void initAndValidate() {
 
         traitNameInput.setValue("date-backward", this);
-
-        StringBuilder valueBuilder = new StringBuilder();
-
-        boolean isFirst = true;
-        for (Node leaf : treeInput.get().getExternalNodes()) {
-            if (isFirst)
-                isFirst = false;
-            else
-                valueBuilder.append(",");
-            valueBuilder.append(leaf.getID() + "=" + leaf.getHeight());
-        }
-
-        traitsInput.setValue(valueBuilder.toString(), this);
-
+        typeLabelInput.setValue("date", this);
         super.initAndValidate();
     }
 }

--- a/src/beast/core/util/TipTypesFromTree.java
+++ b/src/beast/core/util/TipTypesFromTree.java
@@ -1,0 +1,42 @@
+package beast.core.util;
+
+import beast.core.Description;
+import beast.core.Input;
+import beast.evolution.tree.Node;
+import beast.evolution.tree.TraitSet;
+import beast.evolution.tree.Tree;
+
+@Description("Acquire trait set values from tree leaf metadata.")
+public class TipTypesFromTree extends TraitSet {
+
+    public Input<String> typeLabelInput = new Input<>("typeLabel",
+            "Type label used in tree metadata.",
+            Input.Validate.REQUIRED);
+
+    public Input<Tree> treeInput = new Input<>("tree", "Tree from which to " +
+            "extract metadata.", Input.Validate.REQUIRED);
+
+    public TipTypesFromTree() {
+        traitsInput.setRule(Input.Validate.OPTIONAL);
+    }
+
+    @Override
+    public void initAndValidate() {
+
+        StringBuilder valueBuilder = new StringBuilder();
+
+        boolean isFirst = true;
+        for (Node leaf : treeInput.get().getExternalNodes()) {
+            if (isFirst)
+                isFirst = false;
+            else
+                valueBuilder.append(",");
+            valueBuilder.append(leaf.getID()).append("=")
+                    .append(leaf.getMetaData(typeLabelInput.get()));
+        }
+
+        traitsInput.setValue(valueBuilder.toString(), this);
+
+        super.initAndValidate();
+    }
+}


### PR DESCRIPTION
This PR adds a new class allowing general TraitSets to be created from tree metadata.  Useful in initializing BDMM or other analyses (even DTA) using simulated trees.