### PR TITLE
Added missing operators to beauti templates.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,37 +1,44 @@
 <project default="build" basedir=".">
 
+    <property environment="env"/>
+
     <!-- Source, JUnit test code and jar library locations. -->
     <property name="src" location="src"/>
-    <property name="src/test" location="src/test"/>
+    <property name="test" location="test"/>
     <property name="lib" location="lib"/>
 
     <!-- Location to check for local copy of beast2 repository -->
-    <property name="beastDir" location="../beast2"/>
-    <property name="libBeast2" location="${beastDir}/lib" />
+    <property name="local-beast-source-root" location="../beast2"/>
+    <property name="local-beastfx-source-root" location="../BeastFX"/>
 
-    <!-- BEAST 2 currently uses Java 17 -->
-    <property name="sourceVersion" value="17"/>
-    <property name="targetVersion" value="17"/>
+    <!-- BEAST 2 currently uses Java 1.8 -->
+    <property name="sourceVersion" value="1.8"/>
+    <property name="targetVersion" value="1.8"/>
 
     <!-- Directories necessary for all BEAST 2 packages -->
     <property name="doc" location="doc"/>
     <property name="examples" location="examples"/>
     <property name="scripts" location="scripts"/>
-    <property name="templates" location="fxtemplates"/>
+    <property name="fxtemplates" location="fxtemplates"/>
 
     <!-- BEAST branch and version to build against
          (only different for version tags because of
          a Github peculiarity) -->
     <property name="beast-branch" value="master"/>
     <property name="beast-version" value="master"/>
+    <property name="beastfx-branch" value="master"/>
+    <property name="beastfx-version" value="master"/>
 
     <!-- Names of temporary build/test directories -->
     <property name="build" location="build"/>
-    <property name="build-lib" location="build-lib"/>
+    <property name="build-beast" location="build-beast"/>
+    <property name="build-beastfx" location="build-beastfx"/>
+    <property name="beast-source-root" location="beast-source"/>
+    <property name="beastfx-source-root" location="beastfx-source"/>
+    <property name="build-test" location="build-test"/>
     <property name="test-reports" location="test-reports"/>
     <property name="dist" location="dist"/>
     <property name="pack" location="${dist}/package"/>
-    <property name="depends" location="depends"/>
 
     <!-- Prepare for compilation -->
     <target name="init">
@@ -50,125 +57,163 @@
         <property name="projVersion" value="${fromVersionFile.package(version)}" />
 
         <mkdir dir="${build}"/>
-        <mkdir dir="${build-lib}"/>
-        <mkdir dir="${depends}"/>
         <mkdir dir="${dist}"/>
 
-        <copy todir="${build-lib}">
-            <fileset dir="${lib}" includes="*.jar"/>
-        </copy>
     </target>
 
     <!-- Get beast -->
 
     <target name="find-beast" depends="init">
-        <available file="${beastDir}" property="localBeastAvailable"/>
+        <available file="${local-beast-source-root}" property="localBeastAvailable"/>
     </target>
 
-    <target name="build-remote-beast" depends="find-beast" unless="localBeastAvailable">
-        <echo>No local copy of the beast2 source found at ${beastDir}.</echo>
+    <target name="get-remote-beast" depends="find-beast" unless="localBeastAvailable">
+        <echo>No local copy of the beast2 source found at ${local-beast-source-root}.</echo>
         <echo>Compiling against version ${beast-version} from GitHub.</echo>
 
-        <property name="build-beast" location="build-beast"/>
-        <mkdir dir="${build-beast}"/>
+        <mkdir dir="beast-archive"/>
 
-        <get src="https://github.com/CompEvol/beast2/archive/${beast-branch}.zip" dest="${build-beast}/beast.zip"/>
-        <unzip src="${build-beast}/beast.zip" dest="${build-beast}"/>
-        <mkdir dir="${build-beast}/beast2-${beast-version}/build"/>
-        <javac target="${targetVersion}" source="${sourceVersion}"
-            srcdir="${build-beast}/beast2-${beast-version}/src"
-            destdir="${build-beast}/beast2-${beast-version}/build" includeantruntime="false">
-            <classpath>
-                <pathelement path="${classpath}"/>
-                <fileset dir="${build-beast}/beast2-${beast-version}/lib" includes="*.jar"/>
-            </classpath>
-        </javac>
-        <jar jarfile="${build-lib}/beast2.jar" basedir="${build-beast}/beast2-${beast-version}/build" />
-        <copy todir="${build-lib}">
-            <fileset dir="${build-beast}/beast2-${beast-version}/lib" includes="*.jar"/>
+        <get src="https://github.com/CompEvol/beast2/archive/${beast-branch}.zip"
+             dest="beast-archive/beast.zip"/>
+        <unzip src="beast-archive/beast.zip" dest="beast-archive"/>
+
+        <copy todir="${beast-source-root}">
+              <fileset dir="beast-archive/beast2-${beast-version}" includes="**/*.*"/>
         </copy>
 
-        <delete dir="${build-beast}" />
+        <delete dir="beast-archive"/>
     </target>
 
-    <target name="build-local-beast" depends="find-beast" if="localBeastAvailable">
-        <echo>Compiling against beast2 source found at ${beastDir}.</echo>
+    <target name="get-local-beast" depends="find-beast" if="localBeastAvailable">
+        <echo>Compiling against beast2 source found at ${local-beast-source-root}.</echo>
 
-        <property name="build-beast" location="build-beast"/>
-        <mkdir dir="${build-beast}"/>
+        <copy todir="${beast-source-root}">
+          <fileset dir="${local-beast-source-root}" includes="**/*.*"/>
+        </copy>
+    </target>
 
-        <javac target="${targetVersion}" source="${sourceVersion}"
-            srcdir="${beastDir}/src"
-            destdir="${build-beast}" includeantruntime="false">
-            <classpath>
-                <pathelement path="${classpath}"/>
-                <fileset dir="${beastDir}/lib" includes="*.jar"/>
-                <fileset dir="${libBeast2}/junit" includes="*.jar"/>
-                <pathelement path="../BeastFX/build"/>
-                <pathelement path="../MultiTypeTree/build"/>
-                <pathelement path="../MASTER/build"/>
+    <target name="build-beast" depends="get-local-beast,get-remote-beast">
+      <mkdir dir="${build-beast}"/>
+      <javac 
+          srcdir="${beast-source-root}/src"
+          destdir="${build-beast}"
+          source="${sourceVersion}"
+          target="${targetVersion}"
+          encoding="UTF-8"
+          includeantruntime="false"
+          fork="yes">
+        <classpath>
+          <pathelement path="${classpath}"/>
+          <fileset dir="${beast-source-root}/lib" includes="**/*.jar"/>
+        </classpath>
+      </javac>
+      <javac 
+          srcdir="${beast-source-root}/test"
+          destdir="${build-beast}"
+          source="${sourceVersion}"
+          target="${targetVersion}"
+          encoding="UTF-8"
+          includeantruntime="false"
+          fork="yes">
+        <classpath>
+          <pathelement path="${classpath}"/>
+          <fileset dir="${beast-source-root}/lib" includes="**/*.jar"/>
+        </classpath>
+      </javac>
 
-            </classpath>
-        </javac>
-        <jar jarfile="${build-lib}/beast2.jar" basedir="${build-beast}" />
-        <copy todir="${build-lib}">
-            <fileset dir="${beastDir}/lib" includes="*.jar"/>
+    </target>
+
+
+    <target name="find-beastfx" depends="init">
+        <available file="${local-beastfx-source-root}" property="localBeastFXAvailable"/>
+    </target>
+
+    <target name="get-local-beastfx" depends="find-beastfx" if="localBeastFXAvailable">
+        <echo>Compiling against BeastFX source found at ${local-beastfx-source-root}.</echo>
+
+        <copy todir="${beastfx-source-root}">
+          <fileset dir="${local-beastfx-source-root}" includes="**/*.*"/>
+        </copy>
+    </target>
+
+    <target name="get-remote-beastfx" depends="find-beastfx" unless="localBeastFXAvailable">
+        <echo>No local copy of the BeastFX source found at ${local-beastfx-source-root}.</echo>
+        <echo>Compiling against version ${beast-version} from GitHub.</echo>
+
+        <mkdir dir="beastfx-archive"/>
+
+        <get src="https://github.com/CompEvol/BeastFX/archive/refs/heads/${beastfx-branch}.zip"
+             dest="beastfx-archive/beast.zip"/>
+        <unzip src="beastfx-archive/beast.zip" dest="beastfx-archive"/>
+
+        <copy todir="${beastfx-source-root}">
+              <fileset dir="beastfx-archive/BeastFX-${beastfx-version}" includes="**/*.*"/>
         </copy>
 
-        <delete dir="${build-beast}" />
+        <delete dir="beastfx-archive"/>
     </target>
 
-    <target name="build-beast" depends="build-local-beast,build-remote-beast"/>
+    <target name="build-beastfx" depends="get-local-beastfx,get-remote-beastfx">
+      <mkdir dir="${build-beastfx}"/>
+        <javac 
+            srcdir="${beastfx-source-root}/src"
+            destdir="${build-beastfx}"
+            source="${sourceVersion}"
+            target="${targetVersion}"
+            includeantruntime="false"
+            fork="yes">
+            <classpath>
+                <pathelement path="${classpath}"/>
+                <fileset dir="${beastfx-source-root}/locallib" includes="**/*.jar"/>
+                <fileset dir="${env.JAVA_FX_HOME}" includes="**/*.jar"/>
+                <fileset dir="${beast-source-root}/lib" includes="**/*.jar"/>
+                <pathelement path="${build-beast}"/>
+            </classpath>
+        </javac>
+    </target>
 
-    <target name="get-dependencies">
-      <echo>Downloading dependencies...</echo>
-
-
-       <!--
-      <echo>MultiTypeTree:</echo>
-      <get src="https://github.com/tgvaughan/MultiTypeTree/releases/download/v7.0.1/MultiTypeTree.v7.0.1.zip"
-           dest="${build-lib}/MultiTypeTree.zip"/>
-      <mkdir dir="${build-lib}/MultiTypeTree"/>
-      <unzip src="${build-lib}/MultiTypeTree.zip" dest="${build-lib}/MultiTypeTree"/>
-      <move todir="${build-lib}">
-        <fileset dir="${build-lib}/MultiTypeTree/lib" includes="*.jar"/>
-      </move>
-
-
-      <echo>MASTER:</echo>
-      <get src="https://github.com/tgvaughan/MASTER/releases/download/v6.1.1/MASTER.package.v6.1.1.zip"
-           dest="${build-lib}/MASTER.zip"/>
-      <mkdir dir="${build-lib}/MASTER"/>
-      <unzip src="${build-lib}/MASTER.zip" dest="${build-lib}/MASTER"/>
-      <move todir="${build-lib}">
-        <fileset dir="${build-lib}/MASTER/lib" includes="*.jar"/>
-      </move>
-        
-
-
-      <echo>SA:</echo>
-      <get src="https://github.com/CompEvol/sampled-ancestors/releases/download/v2.0.2/SA.v2.0.2.zip"
-           dest="${build-lib}/SA.zip"/>
-      <mkdir dir="${build-lib}/SA"/>
-      <unzip src="${build-lib}/SA.zip" dest="${build-lib}/SA"/>
-      <move todir="${build-lib}">
-        <fileset dir="${build-lib}/SA/lib" includes="*.jar"/>
-      </move>
-    -->
+    <target name="install-dependencies" depends="build-beast">
+      <mkdir dir="deps"/>
+      <java fork="true" classname="beast.pkgmgmt.PackageManager">
+        <jvmarg line="-Dbeast.user.package.dir=./deps"/>
+        <arg line="-add MultiTypeTree"/>
+        <classpath>
+          <pathelement path="${build-beast}"/>
+        </classpath>
+      </java>
+      <java fork="true" classname="beast.pkgmgmt.PackageManager">
+        <jvmarg line="-Dbeast.user.package.dir=./deps"/>
+        <arg line="-add MASTER"/>
+        <classpath>
+          <pathelement path="${build-beast}"/>
+        </classpath>
+      </java>
+      <java fork="true" classname="beast.pkgmgmt.PackageManager">
+        <jvmarg line="-Dbeast.user.package.dir=./deps"/>
+        <arg line="-add SA"/>
+        <classpath>
+          <pathelement path="${build-beast}"/>
+        </classpath>
+      </java>
 
     </target>
 
     <!-- Compile -->
-    <target name="compile" depends="build-beast, get-dependencies">
-        <javac target="${targetVersion}" source="${sourceVersion}" srcdir="${src}" destdir="${build}" includeantruntime="false">
+    <target name="compile" depends="build-beast,build-beastfx,install-dependencies">
+      <javac target="${targetVersion}" source="${sourceVersion}"
+             srcdir="${src}" destdir="${build}"
+             includeantruntime="false" fork="yes">
             <classpath>
                 <pathelement path="${classpath}"/>
-                <fileset dir="${build-lib}" includes="*.jar"/>
-                <fileset dir="${libBeast2}" includes="*.jar"/>
-                <fileset dir="${libBeast2}/junit" includes="*.jar"/>
-                <pathelement path="../BeastFX/build"/>
-                <pathelement path="../MultiTypeTree/build"/>
-                <pathelement path="../MASTER/build"/>
+                <fileset dir="${lib}" includes="**/*.jar"/>
+                <fileset dir="${beast-source-root}/lib" includes="**/*.jar"/>
+                <pathelement path="${build-beast}"/>
+                <fileset dir="${beastfx-source-root}/locallib" includes="**/*.jar"/>
+                <pathelement path="${build-beastfx}"/>
+                <fileset dir="${env.JAVA_FX_HOME}" includes="**/*.jar"/>
+                <fileset dir="deps/MultiTypeTree" includes="**/*.jar"/>
+                <fileset dir="deps/MASTER" includes="**/*.jar"/>
+                <fileset dir="deps/SA" includes="**/*.jar"/>
             </classpath>
         </javac>
     </target>
@@ -182,29 +227,50 @@
 
     <!-- Prepare for unit test compilation -->
     <target name="init-test" depends="init">
+        <mkdir dir="${build-test}"/>
         <mkdir dir="${test-reports}"/>
     </target>
 
-    <!-- Run unit tests -->
-    <target name="test" depends="compile,init-test">
-        <junit printsummary="yes" failureproperty="testFailed" showoutput="true">
+    <!-- Compile unit tests -->
+    <target name="compile-test" depends="init-test,compile,copy-resources">
+      <javac target="${targetVersion}" source="${sourceVersion}"
+             srcdir="${test}" destdir="${build-test}"
+             includeantruntime="false" fork="yes">
             <classpath>
                 <pathelement path="${classpath}"/>
                 <pathelement path="${build}" />
-                <fileset dir="${build-lib}" includes="*.jar"/>
-                <fileset dir="${lib}" includes="*.jar"/>
-                <fileset dir="${libBeast2}" includes="*.jar"/>
-                <fileset dir="${libBeast2}/junit" includes="*.jar"/>
-                <pathelement path="../BeastFX/build"/>
-                <pathelement path="../MultiTypeTree/build"/>
-                <pathelement path="../MASTER/build"/>
+                <fileset dir="${lib}" includes="**/*.jar"/>
+                <fileset dir="${beast-source-root}/lib" includes="**/*.jar"/>
+                <pathelement path="${build-beast}"/>
+                <fileset dir="deps/MultiTypeTree" includes="**/*.jar"/>
+                <fileset dir="deps/MASTER" includes="**/*.jar"/>
+                <fileset dir="deps/SA" includes="**/*.jar"/>
             </classpath>
-            <batchtest fork="yes" todir="${test-reports}">
-                <fileset dir="${build}">
-                    <include name="**/*Test.class"/>
+        </javac>
+    </target>
+
+
+    <!-- Run unit tests -->
+    <target name="test" depends="compile-test">
+      <junit printsummary="yes" failureproperty="testFailed" showoutput="true"
+             maxmemory="4G">
+            <classpath>
+                <pathelement path="${classpath}"/>
+                <pathelement path="${build}" />
+                <pathelement path="${build-test}" />
+                <fileset dir="${lib}" includes="**/*.jar"/>
+                <fileset dir="${beast-source-root}/lib" includes="**/*.jar"/>
+                <pathelement path="${build-beast}" />
+                <fileset dir="deps/MultiTypeTree" includes="**/*.jar"/>
+                <fileset dir="deps/MASTER" includes="**/*.jar"/>
+                <fileset dir="deps/SA" includes="**/*.jar"/>
+            </classpath>
+            <batchtest fork="true" todir="${test-reports}">
+                <fileset dir="${test}">
+                    <include name="**/*Test.java"/>
                 </fileset>
                 <formatter type="plain"/>
-                <formatter type="plain" usefile="false"/> <!-- to screen -->
+                <!-- <formatter type="plain" usefile="false"/> <!-\- to screen -\-> -->
             </batchtest>
         </junit>
 
@@ -232,8 +298,7 @@
         <jar jarfile="${pack}/lib/${fullName}.jar" basedir="${build}" />
 
         <copy file="README.md" tofile="${pack}/README" />
-        <copy file="COPYING" todir="${pack}" failonerror="false" quiet="true" />
-        <copy file="LICENSE" todir="${pack}" failonerror="false" quiet="true" />
+        <copy file="LICENSE" todir="${pack}" />
         <copy todir="${pack}">
             <fileset dir="${lib}" includes="LICENSE*" />
         </copy>
@@ -242,6 +307,9 @@
         <copy todir="${pack}/examples">
             <fileset dir="${examples}" includes="**/*.xml" />
             <fileset dir="${examples}" includes="**/*.fasta" />
+            <fileset dir="${examples}" includes="**/*.fna" />
+            <fileset dir="${examples}" includes="**/*.nexus" />
+            <fileset dir="${examples}" includes="**/*.txt" />
         </copy>
 
         <mkdir dir="${scripts}" />
@@ -250,9 +318,9 @@
         </copy>
 
 
-        <mkdir dir="${templates}" />
+        <mkdir dir="${fxtemplates}" />
         <copy todir="${pack}/fxtemplates">
-            <fileset dir="${templates}" includes="*.xml" />
+            <fileset dir="${fxtemplates}" includes="*.xml" />
         </copy>
 
         <mkdir dir="${doc}" />
@@ -275,9 +343,14 @@
     <!-- Revert to pristine state. -->
     <target name="clean">
         <delete dir="${build}" />
-        <delete dir="${build-lib}" />
+        <delete dir="${build-beast}" />
+        <delete dir="${build-beastfx}" />
+        <delete dir="${beast-source-root}" />
+        <delete dir="${beastfx-source-root}" />
         <delete dir="${dist}" />
+        <delete dir="${build-test}" />
         <delete dir="${test-reports}" />
+        <delete dir="deps" />
     </target>
 
 
@@ -344,7 +417,7 @@
         <mkdir dir="${test}"/>
         <mkdir dir="${lib}"/>
         <mkdir dir="${examples}"/>
-        <mkdir dir="${templates}"/>
+        <mkdir dir="${fxtemplates}"/>
         <mkdir dir="${doc}"/>
 
         <echo/>
@@ -352,10 +425,10 @@
         <echo/>
         <echo>The directory structure is as follows:</echo>
         <echo>${src} - your java source goes here</echo>
-        <echo>${test} - your junit tests go here (You _are_ going to write, those, aren't you!)</echo>
+        <echo>${test} - your junit tests go here (You _are_ going to write those, aren't you!)</echo>
         <echo>${doc} - your documentation goes here</echo>
         <echo>${examples} - your example XML scripts go here</echo>
-        <echo>${templates} - your BEAUti templates go here</echo>
+        <echo>${fxtemplates} - your BEAUti fxtemplates go here</echo>
         <echo/>
         <echo>To build your package, just type "ant" at the command line.</echo>
         <echo/>

--- a/fxtemplates/MultiTypeBirthDeath.xml
+++ b/fxtemplates/MultiTypeBirthDeath.xml
@@ -299,10 +299,6 @@
 
             <!-- Parameter operators -->
             
-            <operator id='proportionInvariantScaler.s:$(n)' spec='ScaleOperator' scaleFactor="0.5" weight="0.1" parameter="@proportionInvariant.s:$(n)"/>
-            <operator id='mutationRateScaler.s:$(n)' spec='ScaleOperator' scaleFactor="0.5" weight="0.1" parameter="@mutationRate.s:$(n)"/>
-            <operator id='gammaShapeScaler.s:$(n)' spec='ScaleOperator' scaleFactor="0.5" weight="0.1" parameter="@gammaShape.s:$(n)"/>
-
 			<operator id="R0Scaler.t:$(n)" parameter="@R0.t:$(n)" scaleFactor="0.8" spec="ScaleOperator" weight="3" />
 			<operator id="becomeUninfectiousRateScaler.t:$(n)" parameter="@becomeUninfectiousRate.t:$(n)" scaleFactor="0.9" spec="ScaleOperator" weight="1" scaleAll="true" optimise="false"/>
 			<operator id="samplingScaler.t:$(n)" parameter="@samplingProportion.t:$(n)" scaleFactor="0.9" spec="ScaleOperator" weight="3.0" />
@@ -326,6 +322,59 @@
 			<operator id="geo-frequenciesExchange.t:$(n)" spec="DeltaExchangeOperator" parameter="@geo-frequencies.t:$(n)" delta="0.1" weight=".1"/>
 
             <operator id='rateMatrixScaler.t:$(n)' spec='ScaleOperator' scaleFactor="0.8" weight="1" parameter="@rateMatrix.t:$(n)"/>
+
+
+			<operator id="AVMNOperator.$(n)" spec="beast.base.evolution.operator.kernel.AdaptableVarianceMultivariateNormalOperator" weight="0.1"
+                coefficient="1.0"
+                scaleFactor="1"
+                beta="0.05"
+                initial="800"
+                burnin="400"
+                every="1" allowNonsense="true">
+            	<transformations id="AVMNSumTransform.$(n)" spec="beast.base.inference.operator.kernel.Transform$LogConstrainedSumTransform" sum="1.0">
+            		<!-- frequencies -->
+            	</transformations>
+            	<transformations id="AVMNLogTransform.$(n)" spec="beast.base.inference.operator.kernel.Transform$LogTransform">
+             		<!-- site and substitution model parameters -->
+            	</transformations>
+            	<transformations id="AVMNNoTransform.$(n)" spec="beast.base.inference.operator.kernel.Transform$NoTransform">
+             		<!-- tree -->
+            	</transformations>
+            </operator>
+
+	        <operator id="StrictClockRateScaler.c:$(n)" spec="beast.base.evolution.operator.AdaptableOperatorSampler" weight="1.5">
+                <parameter idref="clockRate.c:$(n)"/>
+    	        <operator idref="AVMNOperator.$(n)"/>
+        	    <operator id='StrictClockRateScalerX.c:$(n)' spec='kernel.BactrianScaleOperator' scaleFactor="0.75" weight="3" parameter='@clockRate.c:$(n)'/>
+	        </operator>
+
+        	<operator id="strictClockUpDownOperator.c:$(n)" spec="beast.base.evolution.operator.AdaptableOperatorSampler" weight="1.5">
+                <parameter idref="clockRate.c:$(n)"/>
+                <tree idref="Tree.t:$(n)"/>
+	            <operator idref="AVMNOperator.$(n)"/>
+				<operator id='strictClockUpDownOperatorX.c:$(n)' spec='kernel.BactrianUpDownOperator' scaleFactor="0.75" weight="3">
+					<up idref="clockRate.c:$(n)"/>
+					<down idref="Tree.t:$(n)"/>
+				</operator>
+    	    </operator>
+
+        	<operator id="proportionInvariantScaler.s:$(n)" spec="beast.base.evolution.operator.AdaptableOperatorSampler" weight="0.05">
+                <parameter idref="proportionInvariant.s:$(n)"/>
+            	<operator idref="AVMNOperator.$(n)"/>
+            	<operator id='proportionInvariantScalerX.s:$(n)' spec='kernel.BactrianScaleOperator' scaleFactor="0.5" weight="0.1" parameter="@proportionInvariant.s:$(n)"/>
+        	</operator>
+
+        	<operator id="mutationRateScaler.s:$(n)" spec="beast.base.evolution.operator.AdaptableOperatorSampler" weight="0.05">
+                <parameter idref="mutationRate.s:$(n)"/>
+            	<operator idref="AVMNOperator.$(n)"/>
+	            <operator id='mutationRateScalerX.s:$(n)' spec='kernel.BactrianScaleOperator' scaleFactor="0.5" weight="0.1" parameter="@mutationRate.s:$(n)"/>
+        	</operator>
+
+        	<operator id="gammaShapeScaler.s:$(n)" spec="beast.base.evolution.operator.AdaptableOperatorSampler" weight="0.05">
+                <parameter idref="gammaShape.s:$(n)"/>
+            	<operator idref="AVMNOperator.$(n)"/>
+	            <operator id='gammaShapeScalerX.s:$(n)' spec='kernel.BactrianScaleOperator' scaleFactor="0.5" weight="0.1" parameter="@gammaShape.s:$(n)"/>
+        	</operator>
 
             <!-- Multi-type tree operators -->
 

--- a/fxtemplates/MultiTypeBirthDeathUncoloured.xml
+++ b/fxtemplates/MultiTypeBirthDeathUncoloured.xml
@@ -307,10 +307,6 @@
 
             <!-- Parameter operators -->
             
-            <operator id='proportionInvariantScaler.s:$(n)' spec='ScaleOperator' scaleFactor="0.5" weight="0.1" parameter="@proportionInvariant.s:$(n)"/>
-            <operator id='mutationRateScaler.s:$(n)' spec='ScaleOperator' scaleFactor="0.5" weight="0.1" parameter="@mutationRate.s:$(n)"/>
-            <operator id='gammaShapeScaler.s:$(n)' spec='ScaleOperator' scaleFactor="0.5" weight="0.1" parameter="@gammaShape.s:$(n)"/>
-
 			<operator id="R0Scaler.t:$(n)" parameter="@R0.t:$(n)" scaleFactor="0.8" spec="ScaleOperator" weight="3" />
 			<operator id="becomeUninfectiousRateScaler.t:$(n)" parameter="@becomeUninfectiousRate.t:$(n)" scaleFactor="0.9" spec="ScaleOperator" weight="1" scaleAll="true" optimise="false"/>
 			<operator id="samplingScaler.t:$(n)" parameter="@samplingProportion.t:$(n)" scaleFactor="0.9" spec="ScaleOperator" weight="3.0" />
@@ -335,6 +331,49 @@
 			<operator id="geo-frequenciesExchange.t:$(n)" spec="DeltaExchangeOperator" parameter="@geo-frequencies.t:$(n)" delta="0.1" weight=".1"/>
 
             <operator id='rateMatrixScaler.t:$(n)' spec='ScaleOperator' scaleFactor="0.8" weight="1" parameter="@rateMatrix.t:$(n)"/>
+
+
+            <operator id="AVMNOperator.$(n)" spec="beast.base.evolution.operator.kernel.AdaptableVarianceMultivariateNormalOperator" weight="0.1"
+                coefficient="1.0"
+                scaleFactor="1"
+                beta="0.05"
+                initial="800"
+                burnin="400"
+                every="1" allowNonsense="true">
+            	<transformations id="AVMNSumTransform.$(n)" spec="beast.base.inference.operator.kernel.Transform$LogConstrainedSumTransform" sum="1.0">
+            		<!-- frequencies -->
+            	</transformations>
+            	<transformations id="AVMNLogTransform.$(n)" spec="beast.base.inference.operator.kernel.Transform$LogTransform">
+             		<!-- site and substitution model parameters -->
+            	</transformations>
+            	<transformations id="AVMNNoTransform.$(n)" spec="beast.base.inference.operator.kernel.Transform$NoTransform">
+             		<!-- tree -->
+            	</transformations>
+            </operator>
+
+            <operator id="StrictClockRateScaler.c:$(n)" spec="beast.base.evolution.operator.AdaptableOperatorSampler" weight="1.5">
+                <parameter idref="clockRate.c:$(n)"/>
+    	        <operator idref="AVMNOperator.$(n)"/>
+        	    <operator id='StrictClockRateScalerX.c:$(n)' spec='kernel.BactrianScaleOperator' scaleFactor="0.75" weight="3" parameter='@clockRate.c:$(n)'/>
+	        </operator>
+
+	        <operator id="proportionInvariantScaler.s:$(n)" spec="beast.base.evolution.operator.AdaptableOperatorSampler" weight="0.05">
+                <parameter idref="proportionInvariant.s:$(n)"/>
+            	<operator idref="AVMNOperator.$(n)"/>
+            	<operator id='proportionInvariantScalerX.s:$(n)' spec='kernel.BactrianScaleOperator' scaleFactor="0.5" weight="0.1" parameter="@proportionInvariant.s:$(n)"/>
+        	</operator>
+
+        	<operator id="mutationRateScaler.s:$(n)" spec="beast.base.evolution.operator.AdaptableOperatorSampler" weight="0.05">
+                <parameter idref="mutationRate.s:$(n)"/>
+            	<operator idref="AVMNOperator.$(n)"/>
+	            <operator id='mutationRateScalerX.s:$(n)' spec='kernel.BactrianScaleOperator' scaleFactor="0.5" weight="0.1" parameter="@mutationRate.s:$(n)"/>
+        	</operator>
+
+        	<operator id="gammaShapeScaler.s:$(n)" spec="beast.base.evolution.operator.AdaptableOperatorSampler" weight="0.05">
+                <parameter idref="gammaShape.s:$(n)"/>
+            	<operator idref="AVMNOperator.$(n)"/>
+	            <operator id='gammaShapeScalerX.s:$(n)' spec='kernel.BactrianScaleOperator' scaleFactor="0.5" weight="0.1" parameter="@gammaShape.s:$(n)"/>
+        	</operator>
 
             <!-- Tree operators -->
 

--- a/src/bdmm/app/beauti/BirthDeathMigrationInputEditor.java
+++ b/src/bdmm/app/beauti/BirthDeathMigrationInputEditor.java
@@ -133,28 +133,28 @@ public class BirthDeathMigrationInputEditor extends InputEditor.Base {
         r0Box = new HBox();
         r0ModelVals = new ArrayList<>();
         R0EstCheckBox = new CheckBox("estimate");
-        this.initParameter(gridPane, 1, bdmm.R0.get(), "Reproduction number per type:", r0Box, r0ModelVals, R0EstCheckBox, bdmm.R0.getTipText(), ndim);
+        this.initParameter(gridPane, 1, (RealParameter) bdmm.R0.get(), "Reproduction number per type:", r0Box, r0ModelVals, R0EstCheckBox, bdmm.R0.getTipText(), ndim);
 
         
         // Init delta
         deltaBox = new HBox();
         deltaModelVals = new ArrayList<>();
         deltaEstCheckBox = new CheckBox("estimate");
-        this.initParameter(gridPane, 2, bdmm.becomeUninfectiousRate.get(),"BecomeUninfectionRate per type:", deltaBox, deltaModelVals, deltaEstCheckBox, bdmm.becomeUninfectiousRate.getTipText(), ndim);
+        this.initParameter(gridPane, 2, (RealParameter) bdmm.becomeUninfectiousRate.get(),"BecomeUninfectionRate per type:", deltaBox, deltaModelVals, deltaEstCheckBox, bdmm.becomeUninfectiousRate.getTipText(), ndim);
         
         
         // Init sampling proportion
         samplingBox = new HBox();
         samplingModelVals = new ArrayList<>();
         samplingEstCheckBox = new CheckBox("estimate");
-        this.initParameter(gridPane, 3, bdmm.samplingProportion.get(), "SamplingProportion per type:", samplingBox, samplingModelVals, samplingEstCheckBox, bdmm.samplingProportion.getTipText(), ndim*2);
+        this.initParameter(gridPane, 3, (RealParameter) bdmm.samplingProportion.get(), "SamplingProportion per type:", samplingBox, samplingModelVals, samplingEstCheckBox, bdmm.samplingProportion.getTipText(), ndim*2);
 
         
         
         // Init sampling change times but hide the first box
         samplingChangeBox = new HBox();
         samplingChangeModelVals = new ArrayList<>();
-        this.initParameter(gridPane, 4, bdmm.samplingRateChangeTimesInput.get(), "Sampling change time:", samplingChangeBox, samplingChangeModelVals, null, bdmm.samplingRateChangeTimesInput.getTipText(), 2);
+        this.initParameter(gridPane, 4, (RealParameter) bdmm.samplingRateChangeTimesInput.get(), "Sampling change time:", samplingChangeBox, samplingChangeModelVals, null, bdmm.samplingRateChangeTimesInput.getTipText(), 2);
         samplingChangeModelVals.get(0).setVisible(false);
         samplingChangeModelVals.get(0).setManaged(false);
         
@@ -164,7 +164,7 @@ public class BirthDeathMigrationInputEditor extends InputEditor.Base {
         rateMatrixBoxes = new ArrayList<>();
         rateMatrixModelVals = new ArrayList<>();
         rateMatrixEstCheckBox = new CheckBox("estimate");
-    	this.initMatrix(gridPane, 5, bdmm.migrationMatrix.get(), rateMatrixTextFieldBox, "Migration rates:", rateMatrixBoxes, rateMatrixModelVals, rateMatrixEstCheckBox, bdmm.migrationMatrix.getTipText(), ndim);
+    	this.initMatrix(gridPane, 5, (RealParameter) bdmm.migrationMatrix.get(), rateMatrixTextFieldBox, "Migration rates:", rateMatrixBoxes, rateMatrixModelVals, rateMatrixEstCheckBox, bdmm.migrationMatrix.getTipText(), ndim);
         	  
         
         
@@ -194,19 +194,19 @@ public class BirthDeathMigrationInputEditor extends InputEditor.Base {
 
 
              // Update R0
-             setVectorDimension(bdmm.R0.get(), r0Box, r0ModelVals, oldDim, newDim, bdmm.R0.getTipText());
+             setVectorDimension((RealParameter) bdmm.R0.get(), r0Box, r0ModelVals, oldDim, newDim, bdmm.R0.getTipText());
              
              // Update delta
-             setVectorDimension(bdmm.becomeUninfectiousRate.get(), deltaBox, deltaModelVals, oldDim, newDim, bdmm.becomeUninfectiousRate.getTipText());
+             setVectorDimension((RealParameter) bdmm.becomeUninfectiousRate.get(), deltaBox, deltaModelVals, oldDim, newDim, bdmm.becomeUninfectiousRate.getTipText());
 
              // Update sampling proportion
-             setVectorDimension(bdmm.samplingProportion.get(), samplingBox, samplingModelVals, oldDim*2, newDim*2, bdmm.samplingProportion.getTipText());
+             setVectorDimension((RealParameter) bdmm.samplingProportion.get(), samplingBox, samplingModelVals, oldDim*2, newDim*2, bdmm.samplingProportion.getTipText());
 
              // Update sampling change times 
-             setVectorDimension(bdmm.samplingRateChangeTimesInput.get(), samplingChangeBox, samplingChangeModelVals, 2, 2, bdmm.samplingRateChangeTimesInput.getTipText());
+             setVectorDimension((RealParameter) bdmm.samplingRateChangeTimesInput.get(), samplingChangeBox, samplingChangeModelVals, 2, 2, bdmm.samplingRateChangeTimesInput.getTipText());
 
              // Update migration matrix 
-             setMatrixDimension(bdmm.migrationMatrix.get(), rateMatrixTextFieldBox, rateMatrixBoxes, rateMatrixModelVals, newDim, bdmm.migrationMatrix.getTipText());
+             setMatrixDimension((RealParameter) bdmm.migrationMatrix.get(), rateMatrixTextFieldBox, rateMatrixBoxes, rateMatrixModelVals, newDim, bdmm.migrationMatrix.getTipText());
              
              
              System.out.println(" r0ModelVals " + r0ModelVals.size());
@@ -227,10 +227,10 @@ public class BirthDeathMigrationInputEditor extends InputEditor.Base {
                      sbfreqs.append(Double.toString(fr));
 
              }
-            
-             bdmm.frequencies.get().valuesInput.setValue(sbfreqs.toString(), bdmm.frequencies.get());
-             bdmm.frequencies.get().setDimension(newDim);
-             bdmm.frequencies.get().initAndValidate();
+
+			((RealParameter) bdmm.frequencies.get()).valuesInput.setValue(sbfreqs.toString(), (RealParameter) bdmm.frequencies.get());
+			((RealParameter) bdmm.frequencies.get()).setDimension(newDim);
+			((RealParameter) bdmm.frequencies.get()).initAndValidate();
              bdmm.stateNumber.setValue(newDim, bdmm);
              //bdmm.setInputValue("stateNumber", newDim);
              
@@ -273,7 +273,7 @@ public class BirthDeathMigrationInputEditor extends InputEditor.Base {
         
         // Add estimate checkbox
         if (checkBox != null) {
-	        checkBox.setSelected(bdmm.R0.get().isEstimatedInput.get());
+	        checkBox.setSelected(((RealParameter) bdmm.R0.get()).isEstimatedInput.get());
 	        checkBox.setTooltip(new Tooltip("Estimate value of this parameter in the MCMC chain"));
 	        
 	        
@@ -298,7 +298,6 @@ public class BirthDeathMigrationInputEditor extends InputEditor.Base {
      * @param param
      * @param name
      * @param hboxes
-     * @param vector
      * @param checkBox
      * @param tooltip
      * @param ndim
@@ -344,7 +343,7 @@ public class BirthDeathMigrationInputEditor extends InputEditor.Base {
         
         // Add estimate checkbox
         if (checkBox != null) {
-	        checkBox.setSelected(bdmm.R0.get().isEstimatedInput.get());
+	        checkBox.setSelected(((RealParameter) bdmm.R0.get()).isEstimatedInput.get());
 	        checkBox.setTooltip(new Tooltip("Estimate value of this parameter in the MCMC chain"));
 	        
 	        
@@ -405,7 +404,6 @@ public class BirthDeathMigrationInputEditor extends InputEditor.Base {
     /**
      * Saves a parameter from the gui to bdmm
      * @param param
-     * @param vector
      */
     private void saveMatrix(RealParameter param, List<List<TextField>> matrix, Boolean selected, int ndim) {
     	
@@ -475,10 +473,6 @@ public class BirthDeathMigrationInputEditor extends InputEditor.Base {
     /**
      * Same as above but for a matrix
      * @param param
-     * @param rateMatrixModelVals2
-     * @param rateMatrixBoxes2
-     * @param rateMatrixEstCheckBox2
-     * @param tipText
      */
     private void loadMatrix(RealParameter param, VBox vbox, List<List<TextField>> matrix, List<HBox> hboxes, CheckBox checkBox, String tooltip, int ndim) {
 		
@@ -565,8 +559,6 @@ public class BirthDeathMigrationInputEditor extends InputEditor.Base {
      * @param vbox
      * @param hboxes
      * @param matrix
-     * @param oldDim
-     * @param newDim
      * @param tooltip
      */
     private void setMatrixDimension(RealParameter param, VBox vbox, List<HBox> hboxes, List<List<TextField>> matrix, int ndim, String tooltip) {
@@ -663,11 +655,11 @@ public class BirthDeathMigrationInputEditor extends InputEditor.Base {
     	
     	dimSpinner.getValueFactory().setValue(ndim);
     
-    	this.loadParameter(bdmm.R0.get(), r0ModelVals, r0Box, R0EstCheckBox, bdmm.R0.getTipText());
-    	this.loadParameter(bdmm.becomeUninfectiousRate.get(), deltaModelVals, deltaBox, deltaEstCheckBox, bdmm.becomeUninfectiousRate.getTipText());
-    	this.loadParameter(bdmm.samplingProportion.get(), samplingModelVals, samplingBox, samplingEstCheckBox, bdmm.samplingProportion.getTipText());
-    	this.loadParameter(bdmm.samplingRateChangeTimesInput.get(), samplingChangeModelVals, samplingChangeBox, null, bdmm.samplingRateChangeTimesInput.getTipText());
-    	this.loadMatrix(bdmm.migrationMatrix.get(), rateMatrixTextFieldBox, rateMatrixModelVals, rateMatrixBoxes, rateMatrixEstCheckBox, bdmm.migrationMatrix.getTipText(), ndim);
+    	this.loadParameter((RealParameter) bdmm.R0.get(), r0ModelVals, r0Box, R0EstCheckBox, bdmm.R0.getTipText());
+    	this.loadParameter((RealParameter) bdmm.becomeUninfectiousRate.get(), deltaModelVals, deltaBox, deltaEstCheckBox, bdmm.becomeUninfectiousRate.getTipText());
+    	this.loadParameter((RealParameter) bdmm.samplingProportion.get(), samplingModelVals, samplingBox, samplingEstCheckBox, bdmm.samplingProportion.getTipText());
+    	this.loadParameter((RealParameter) bdmm.samplingRateChangeTimesInput.get(), samplingChangeModelVals, samplingChangeBox, null, bdmm.samplingRateChangeTimesInput.getTipText());
+    	this.loadMatrix((RealParameter) bdmm.migrationMatrix.get(), rateMatrixTextFieldBox, rateMatrixModelVals, rateMatrixBoxes, rateMatrixEstCheckBox, bdmm.migrationMatrix.getTipText(), ndim);
     	
     	
     	
@@ -682,18 +674,18 @@ public class BirthDeathMigrationInputEditor extends InputEditor.Base {
     	
     	
     	// Parse parameters
-    	this.saveParameter(bdmm.R0.get(), r0ModelVals, R0EstCheckBox.isSelected(), ndim);
-    	this.saveParameter(bdmm.becomeUninfectiousRate.get(), deltaModelVals, deltaEstCheckBox.isSelected(), ndim);
-    	this.saveParameter(bdmm.samplingProportion.get(), samplingModelVals, samplingEstCheckBox.isSelected(), ndim*2);
-    	this.saveParameter(bdmm.samplingRateChangeTimesInput.get(), samplingChangeModelVals, null, 2);
-    	this.saveMatrix(bdmm.migrationMatrix.get(), rateMatrixModelVals, rateMatrixEstCheckBox.isSelected(), ndim);
+    	this.saveParameter((RealParameter) bdmm.R0.get(), r0ModelVals, R0EstCheckBox.isSelected(), ndim);
+    	this.saveParameter((RealParameter) bdmm.becomeUninfectiousRate.get(), deltaModelVals, deltaEstCheckBox.isSelected(), ndim);
+    	this.saveParameter((RealParameter) bdmm.samplingProportion.get(), samplingModelVals, samplingEstCheckBox.isSelected(), ndim*2);
+    	this.saveParameter((RealParameter) bdmm.samplingRateChangeTimesInput.get(), samplingChangeModelVals, null, 2);
+    	this.saveMatrix((RealParameter) bdmm.migrationMatrix.get(), rateMatrixModelVals, rateMatrixEstCheckBox.isSelected(), ndim);
     	
     	try {
-            bdmm.R0.get().initAndValidate();
-            bdmm.samplingProportion.get().initAndValidate();
-            bdmm.samplingRateChangeTimesInput.get().initAndValidate();
-            bdmm.becomeUninfectiousRate.get().initAndValidate();
-            bdmm.migrationMatrix.get().initAndValidate();
+			((RealParameter)bdmm.R0.get()).initAndValidate();
+			((RealParameter)bdmm.samplingProportion.get()).initAndValidate();
+			((RealParameter)bdmm.samplingRateChangeTimesInput.get()).initAndValidate();
+			((RealParameter)bdmm.becomeUninfectiousRate.get()).initAndValidate();
+			((RealParameter)bdmm.migrationMatrix.get()).initAndValidate();
             bdmm.initAndValidate();
         } catch (Exception ex) {
             ex.printStackTrace();

--- a/src/bdmm/core/util/Utils.java
+++ b/src/bdmm/core/util/Utils.java
@@ -16,7 +16,7 @@ public class Utils {
      * @param m the total number of time intervals + 1 (the total number of time change events)
      * @return
      */
-    public static int index(Double t, Double[] times, int m) {
+    public static int index(double t, double[] times, int m) {
 
         int epoch = Arrays.binarySearch(times, t);
 

--- a/src/bdmm/evolution/speciation/BirthDeathMigrationClusterModelUncoloured.java
+++ b/src/bdmm/evolution/speciation/BirthDeathMigrationClusterModelUncoloured.java
@@ -88,19 +88,19 @@ public class BirthDeathMigrationClusterModelUncoloured extends BirthDeathMigrati
 
 		birth = new double[n*totalIntervals];
 		death = new double[n*totalIntervals];
-		psi = new Double[n*totalIntervals];
-		b_ij = new Double[totalIntervals*(n*(n-1))];
-		M = new Double[totalIntervals*(n*(n-1))];
-		if (SAModel) r =  new Double[n * totalIntervals];
+		psi = new double[n*totalIntervals];
+		b_ij = new double[totalIntervals*(n*(n-1))];
+		M = new double[totalIntervals*(n*(n-1))];
+		if (SAModel) r =  new double[n * totalIntervals];
 
 		if (transform) {
 			transformParameters();
 		}
 		else {
 
-			Double[] birthAmongDemesRates = new Double[1];
+			double[] birthAmongDemesRates = new double[1];
 
-			if (birthAmongDemes) birthAmongDemesRates = birthRateAmongDemes.get().getValues();
+			if (birthAmongDemes) birthAmongDemesRates = birthRateAmongDemes.get().getDoubleValues();
 
 			updateBirthDeathPsiParams();
 
@@ -110,10 +110,10 @@ public class BirthDeathMigrationClusterModelUncoloured extends BirthDeathMigrati
 			}
 		}
 
-        Double[] migRates = migrationMatrix.get().getValues();
-        Double factor;
+        double[] migRates = migrationMatrix.get().getDoubleValues();
+        double factor;
         if (migrationMatrixScaleFactor.get()!=null) {
-            factor = migrationMatrixScaleFactor.get().getValue();
+            factor = migrationMatrixScaleFactor.get().getArrayValue();
             for (int i = 0; i < M.length; i++) M[i] *= factor;
         }
 
@@ -125,7 +125,7 @@ public class BirthDeathMigrationClusterModelUncoloured extends BirthDeathMigrati
         for (int i = 0; i < totalIntervals; i++)
             birth[i]*=getRateForCluster(clusterIndices[currentCluster.get()-1]);
 
-		freq = frequencies.get().getValues();
+		freq = frequencies.get().getDoubleValues();
 
 		setupIntegrators();
 

--- a/src/bdmm/evolution/speciation/BirthDeathMigrationModel.java
+++ b/src/bdmm/evolution/speciation/BirthDeathMigrationModel.java
@@ -196,7 +196,7 @@ public class BirthDeathMigrationModel extends PiecewiseBirthDeathMigrationDistri
 
 		if (Double.isInfinite(logP)) logP = Double.NEGATIVE_INFINITY;
 
-		if (SAModel && !(removalProbability.get().getDimension()==n && removalProbability.get().getValue()==1.)) {
+		if (SAModel && !(removalProbability.get().getDimension()==n && removalProbability.get().getArrayValue()==1.)) {
 			int internalNodeCount = tree.getLeafNodeCount() - ((Tree)tree).getDirectAncestorNodeCount()- 1;
 			logP +=  Math.log(2)*internalNodeCount;
 		}
@@ -283,7 +283,7 @@ public class BirthDeathMigrationModel extends PiecewiseBirthDeathMigrationDistri
 			System.arraycopy(g.conditionsOnP, 0, init.conditionsOnP, 0, n);
 			if (birthAmongDemes) // this might be a birth among demes where only the child with the different type got sampled
 				init.conditionsOnG[prevcol] = g.conditionsOnG[col].scalarMultiply(b_ij[totalIntervals * (prevcol * (n - 1) + (col < prevcol ? col : col - 1)) + index]);
-			if (M[0]!=null)     // or it really is a migration event
+			if (M!=null)     // or it really is a migration event
 				init.conditionsOnG[prevcol] = g.conditionsOnG[col].scalarMultiply(M[totalIntervals * (prevcol * (n - 1) + (col < prevcol ? col : col - 1)) + index]);
 
 			return getG(from, init, to, PG, node, true);
@@ -448,7 +448,7 @@ public class BirthDeathMigrationModel extends PiecewiseBirthDeathMigrationDistri
 
 		if (count>0){
 
-			if (originBranch.getChangeTime(0) < root.getHeight() || originBranch.getChangeTime(count-1) > origin.get().getValue() )
+			if (originBranch.getChangeTime(0) < root.getHeight() || originBranch.getChangeTime(count-1) > origin.get().getArrayValue() )
 				return false;
 
 			if (!allowChangeAtNode && originBranch.getChangeType(0) == root.getFinalType())

--- a/src/bdmm/evolution/speciation/BirthDeathMigrationModelUncoloured.java
+++ b/src/bdmm/evolution/speciation/BirthDeathMigrationModelUncoloured.java
@@ -209,7 +209,7 @@ public class BirthDeathMigrationModelUncoloured extends PiecewiseBirthDeathMigra
 		if (print) System.out.println("\nlogP = " + logP);
 
 		if (Double.isInfinite(logP)) logP = Double.NEGATIVE_INFINITY;
-		if (SAModel && !(removalProbability.get().getDimension()==n && removalProbability.get().getValue()==1.)) {
+		if (SAModel && !(removalProbability.get().getDimension()==n && removalProbability.get().getArrayValue()==1.)) {
 			int internalNodeCount = tree.getLeafNodeCount() - ((Tree)tree).getDirectAncestorNodeCount()- 1;
 			logP +=  Math.log(2)*internalNodeCount;
 		}

--- a/src/bdmm/evolution/speciation/PiecewiseBirthDeathMigrationDistribution.java
+++ b/src/bdmm/evolution/speciation/PiecewiseBirthDeathMigrationDistribution.java
@@ -53,10 +53,10 @@ import java.util.concurrent.ThreadPoolExecutor;
 public abstract class PiecewiseBirthDeathMigrationDistribution extends SpeciesTreeDistribution {
 
 
-	public Input<RealParameter> frequencies =
+	public Input<Function> frequencies =
 			new Input<>("frequencies", "The frequencies for each type",  Input.Validate.REQUIRED);
 
-	public Input<RealParameter> origin =
+	public Input<Function> origin =
 			new Input<>("origin", "The origin of infection x1");
 
 	public Input<Boolean> originIsRootEdge =
@@ -75,30 +75,30 @@ public abstract class PiecewiseBirthDeathMigrationDistribution extends SpeciesTr
 			new Input<>("absTolerance", "absolute tolerance for numerical integration", 1e-100 /*Double.MIN_VALUE*/);
 
 	// the interval times for the migration rates
-	public Input<RealParameter> migChangeTimesInput =
+	public Input<Function> migChangeTimesInput =
 			new Input<>("migChangeTimes", "The times t_i specifying when migration rate changes occur", (RealParameter) null);
 
 	// the interval times for the birth rate
-	public Input<RealParameter> birthRateChangeTimesInput =
+	public Input<Function> birthRateChangeTimesInput =
 			new Input<>("birthRateChangeTimes", "The times t_i specifying when birth/R rate changes occur", (RealParameter) null);
 
 	// the interval times for the birth rate among demes
-	public Input<RealParameter> b_ijChangeTimesInput =
+	public Input<Function> b_ijChangeTimesInput =
 			new Input<>("birthRateAmongDemesChangeTimes", "The times t_i specifying when birth/R among demes changes occur", (RealParameter) null);
 
 	// the interval times for the death rate
-	public Input<RealParameter> deathRateChangeTimesInput =
+	public Input<Function> deathRateChangeTimesInput =
 			new Input<>("deathRateChangeTimes", "The times t_i specifying when death/becomeUninfectious rate changes occur", (RealParameter) null);
 
 	// the interval times for sampling rate
-	public Input<RealParameter> samplingRateChangeTimesInput =
+	public Input<Function> samplingRateChangeTimesInput =
 			new Input<>("samplingRateChangeTimes", "The times t_i specifying when sampling rate or sampling proportion changes occur", (RealParameter) null);
 
 	// the interval times for removal probability
-	public Input<RealParameter> removalProbabilityChangeTimesInput =
-			new Input<RealParameter>("removalProbabilityChangeTimes", "The times t_i specifying when removal probability changes occur", (RealParameter) null);
+	public Input<Function> removalProbabilityChangeTimesInput =
+			new Input<>("removalProbabilityChangeTimes", "The times t_i specifying when removal probability changes occur", (RealParameter) null);
 
-	public Input<RealParameter> intervalTimes =
+	public Input<Function> intervalTimes =
 			new Input<>("intervalTimes", "The time t_i for all parameters if they are the same", (RealParameter) null);
 
 	public Input<Boolean> migTimesRelativeInput =
@@ -124,7 +124,7 @@ public abstract class PiecewiseBirthDeathMigrationDistribution extends SpeciesTr
 					"Careful, rate array must still be given in FORWARD time (root to tips).");
 
 	// the times for rho sampling
-	public Input<RealParameter> rhoSamplingTimes =
+	public Input<Function> rhoSamplingTimes =
 			new Input<>("rhoSamplingTimes", "The times t_i specifying when rho-sampling occurs", (RealParameter) null);
 	public Input<Boolean> contemp =
 			new Input<>("contemp", "Only contemporaneous sampling (i.e. all tips are from same sampling time, default false)", false);
@@ -133,37 +133,37 @@ public abstract class PiecewiseBirthDeathMigrationDistribution extends SpeciesTr
 			new Input<>("birthRate", "BirthRate = BirthRateVector * birthRateScalar, birthrate can change over time");
 	public Input<Function> deathRate =
 			new Input<>("deathRate", "The deathRate vector with birthRates between times");
-	public Input<RealParameter> samplingRate =
+	public Input<Function> samplingRate =
 			new Input<>("samplingRate", "The sampling rate per individual");      // psi
 
-	public Input<RealParameter> m_rho =
+	public Input<Function> m_rho =
 			new Input<>("rho", "The proportion of lineages sampled at rho-sampling times (default 0.)");
 
 
-	public Input<RealParameter> R0 =
+	public Input<Function> R0 =
 			new Input<>("R0", "The basic reproduction number");
-	public Input<RealParameter> becomeUninfectiousRate =
+	public Input<Function> becomeUninfectiousRate =
 			new Input<>("becomeUninfectiousRate", "Rate at which individuals become uninfectious (through recovery or sampling)", Input.Validate.XOR, deathRate);
-	public Input<RealParameter> samplingProportion =
+	public Input<Function> samplingProportion =
 			new Input<>("samplingProportion", "The samplingProportion = samplingRate / becomeUninfectiousRate", Input.Validate.XOR, samplingRate);
 
 	public Input<BooleanParameter> identicalRatesForAllTypesInput =
 			new Input<>("identicalRatesForAllTypes", "True if all types should have the same 1) birth 2) death 3) sampling 4) rho 5) r 6) migration rate. Default false.");
 
-	public Input<RealParameter> R0_base =
+	public Input<Function> R0_base =
 			new Input<>("R0_base",
 					"The basic reproduction number for the base pathogen class, should have the same dimension as " +
 							"the number of time intervals.");
-	public Input<RealParameter> lambda_ratio =
+	public Input<Function> lambda_ratio =
 			new Input<>("lambda_ratio",
 					"The ratio of basic infection rates of all other classes when compared to the base lambda, " +
 							"should have the dimension of the number of pathogens - 1, as it is kept constant over intervals.");
 
-	public Input<RealParameter> migrationMatrix =
+	public Input<Function> migrationMatrix =
 			new Input<>("migrationMatrix", "Flattened migration matrix, can be asymmetric, diagonal entries omitted");
 
 
-	public Input<RealParameter> migrationMatrixScaleFactor =
+	public Input<Function> migrationMatrixScaleFactor =
 			new Input<>("migrationMatrixScaleFactor", "A real number with which each migration rate entry is scaled.");
 
 	// adapted from SCMigrationModel class in package MultiTypeTree by Tim Vaughan
@@ -174,21 +174,21 @@ public abstract class PiecewiseBirthDeathMigrationDistribution extends SpeciesTr
 					+ " (Default is to use all rates.)");
 
 
-	public Input<RealParameter> birthRateAmongDemes =
+	public Input<Function> birthRateAmongDemes =
 			new Input<>("birthRateAmongDemes", "birth rate vector with rate at which transmissions occur among locations");
 
-	public Input<RealParameter> R0AmongDemes =
+	public Input<Function> R0AmongDemes =
 			new Input<>("R0AmongDemes", "The basic reproduction number determining transmissions occur among locations");
 
 
-	public Input<RealParameter> removalProbability =
-			new Input<RealParameter>("removalProbability", "The probability of an individual to become noninfectious immediately after the sampling");
+	public Input<Function> removalProbability =
+			new Input<>("removalProbability", "The probability of an individual to become noninfectious immediately after the sampling");
 
 
 	public Input<Integer> stateNumber =
 			new Input<>("stateNumber", "The number of states or locations", Input.Validate.REQUIRED);
 
-	public Input<RealParameter> adjustTimesInput =
+	public Input<Function> adjustTimesInput =
 			new Input<>("adjustTimes", "Origin of MASTER sims which has to be deducted from the change time arrays");
 	// <!-- HACK ALERT for reestimation from MASTER sims: adjustTimes is used to correct the forward changetimes such that they don't include orig-root (when we're not estimating the origin) -->
 
@@ -203,7 +203,7 @@ public abstract class PiecewiseBirthDeathMigrationDistribution extends SpeciesTr
 	//If a large number a cores is available (more than 8 or 10) the calculation speed can be increased by diminishing the parallelization factor
 	//On the contrary, if only 2-4 cores are available, a slightly higher value (1/5 to 1/8) can be beneficial to the calculation speed.
 	public Input<Double> minimalProportionForParallelizationInput = new Input<>("parallelizationFactor", "the minimal relative size the two children subtrees of a node" +
-			" must have to start parallel calculations on the children. (default: 1/10). ", new Double(1/10));
+			" must have to start parallel calculations on the children. (default: 1/10). ", 0.1);
 
 
 	public static boolean isParallelizedCalculation;
@@ -227,9 +227,9 @@ public abstract class PiecewiseBirthDeathMigrationDistribution extends SpeciesTr
 	// these four arrays are totalIntervals in length
 	protected double[] birth;
 	double[] death;
-	Double[] psi;
-	static  volatile Double[] rho;
-	Double[] r;
+	double[] psi;
+	static  volatile double[] rho;
+	double[] r;
 
 	/**
 	 * The number of change points in the birth rate, b_ij, death rate, sampling rate, rho, r
@@ -264,12 +264,12 @@ public abstract class PiecewiseBirthDeathMigrationDistribution extends SpeciesTr
 	protected List<Double> deathRateChangeTimes = new ArrayList<>();
 	protected List<Double> samplingRateChangeTimes = new ArrayList<>();
 	protected List<Double> rhoSamplingChangeTimes = new ArrayList<>();
-	protected List<Double> rChangeTimes = new ArrayList<Double>();
+	protected List<Double> rChangeTimes = new ArrayList<>();
 
 	Boolean contempData;
 	SortedSet<Double> timesSet = new TreeSet<>();
 
-	protected static volatile Double[] times = new Double[]{0.};
+	protected static volatile double[] times = new double[]{0.};
 
 	protected Boolean transform;
 
@@ -281,11 +281,11 @@ public abstract class PiecewiseBirthDeathMigrationDistribution extends SpeciesTr
 	Boolean rTimesRelative = false;
 	Boolean[] reverseTimeArrays;
 
-	Double[] M;
-	Double[] b_ij;
+	double[] M;
+	double[] b_ij;
 	Boolean birthAmongDemes = false;
 
-	Double[] freq;
+	double[] freq;
 
 	static double[][] pInitialConditions;
 
@@ -330,7 +330,7 @@ public abstract class PiecewiseBirthDeathMigrationDistribution extends SpeciesTr
 
 		Double factor;
 		if (migrationMatrix.get()!=null) {
-			M = migrationMatrix.get().getValues();
+			M = migrationMatrix.get().getDoubleValues();
 
 			if (rateMatrixFlagsInput.get() != null) {
 				rateMatrixFlags = rateMatrixFlagsInput.get();
@@ -347,7 +347,7 @@ public abstract class PiecewiseBirthDeathMigrationDistribution extends SpeciesTr
 
 
 			if (migrationMatrixScaleFactor.get()!=null) {
-				factor = migrationMatrixScaleFactor.get().getValue();
+				factor = migrationMatrixScaleFactor.get().getArrayValue();
 				for (int i = 0; i < M.length; i++) M[i] *= factor;
 			}
 
@@ -395,14 +395,14 @@ public abstract class PiecewiseBirthDeathMigrationDistribution extends SpeciesTr
 
 			transform = false;
 			death = deathRate.get().getDoubleValues();
-			psi = samplingRate.get().getValues();
+			psi = samplingRate.get().getDoubleValues();
 			birth = birthRate.get().getDoubleValues();
-			if (SAModel) r = removalProbability.get().getValues();
+			if (SAModel) r = removalProbability.get().getDoubleValues();
 
 			if (birthRateAmongDemes.get()!=null ){
 
 				birthAmongDemes = true;
-				b_ij=birthRateAmongDemes.get().getValues();
+				b_ij=birthRateAmongDemes.get().getDoubleValues();
 			}
 		} else if ((R0.get() != null || (R0_base.get() != null && lambda_ratio.get() != null)) && becomeUninfectiousRate.get() != null && samplingProportion.get() != null) {
 			transform = true;
@@ -439,11 +439,11 @@ public abstract class PiecewiseBirthDeathMigrationDistribution extends SpeciesTr
 		if (SAModel) rChanges = removalProbability.get().getDimension()/n -1;
 
 		if (m_rho.get()!=null) {
-			rho = m_rho.get().getValues();
+			rho = m_rho.get().getDoubleValues();
 			rhoChanges = m_rho.get().getDimension()/n - 1;
 		}
 
-		freq = frequencies.get().getValues();
+		freq = frequencies.get().getDoubleValues();
 
 		double freqSum = 0;
 		for (double f : freq) freqSum+= f;
@@ -560,8 +560,8 @@ public abstract class PiecewiseBirthDeathMigrationDistribution extends SpeciesTr
 			constantRho = !(m_rho.get().getDimension() > n);
 
 			if (m_rho.get().getDimension() <= n && (rhoSamplingTimes.get()==null || rhoSamplingTimes.get().getDimension() < 2)) {
-				if (!contempData && ((samplingProportion.get() != null && samplingProportion.get().getDimension() <= n && samplingProportion.get().getValue() == 0.) || // todo:  instead of samplingProportion.get().getValue() == 0. need checked that samplingProportion[i]==0 for all i=0..n-1
-						(samplingRate.get() != null && samplingRate.get().getDimension() <= 2 && samplingRate.get().getValue() == 0.))) {                              // todo:  instead of samplingRate.get().getValue() == 0. need checked that samplingRate[i]==0 for all i=0..n-1
+				if (!contempData && ((samplingProportion.get() != null && samplingProportion.get().getDimension() <= n && samplingProportion.get().getArrayValue() == 0.) || // todo:  instead of samplingProportion.get().getValue() == 0. need checked that samplingProportion[i]==0 for all i=0..n-1
+						(samplingRate.get() != null && samplingRate.get().getDimension() <= 2 && samplingRate.get().getArrayValue() == 0.))) {                              // todo:  instead of samplingRate.get().getValue() == 0. need checked that samplingRate[i]==0 for all i=0..n-1
 
 					// check if data set is contemp!
 					for (Node node : treeInput.get().getExternalNodes()){
@@ -578,17 +578,17 @@ public abstract class PiecewiseBirthDeathMigrationDistribution extends SpeciesTr
 					throw new RuntimeException("when contemp=true, rho must have dimension 1 (or equal to the stateNumber)");
 
 				else {
-					rho = new Double[n*totalIntervals];
+					rho = new double[n*totalIntervals];
 					Arrays.fill(rho, 0.);
 					Arrays.fill(isRhoTip, true);
-					for (int i=1; i<=n; i++)  rho[i*totalIntervals - 1] = m_rho.get().getValue(i-1);
+					for (int i=1; i<=n; i++)  rho[i*totalIntervals - 1] = m_rho.get().getArrayValue(i-1);
 
 					rhoSamplingCount = 1;
 				}
 			}
 			else {
-				Double[] rhos = m_rho.get().getValues();
-				rho = new Double[n*totalIntervals];
+				double[] rhos = m_rho.get().getDoubleValues();
+				rho = new double[n*totalIntervals];
 				Arrays.fill(rho, 0.);
 				for (int i = 0; i < totalIntervals; i++) {
 					for (int j=0;j<n;j++){
@@ -600,7 +600,7 @@ public abstract class PiecewiseBirthDeathMigrationDistribution extends SpeciesTr
 
 
 		} else {
-			rho = new Double[n*totalIntervals];
+			rho = new double[n*totalIntervals];
 			Arrays.fill(rho, 0.);
 		}
 
@@ -719,8 +719,8 @@ public abstract class PiecewiseBirthDeathMigrationDistribution extends SpeciesTr
 			}
 		}
 
+		times = timesSet.stream().mapToDouble(Double::doubleValue).toArray();
 
-		times = timesSet.toArray(new Double[timesSet.size()]);
 		// TODO potentially refactor with totalIntervals = times.length-1 so that totalIntervals really represents the number of time intervals
 		totalIntervals = times.length;
 
@@ -729,7 +729,7 @@ public abstract class PiecewiseBirthDeathMigrationDistribution extends SpeciesTr
 	/**
 	 * set change times
 	 */
-	public void getChangeTimes(double maxTime, List<Double> changeTimes, RealParameter intervalTimes, int numChanges, boolean relative, boolean reverse, boolean isPointEvent) {
+	public void getChangeTimes(double maxTime, List<Double> changeTimes, Function intervalTimes, int numChanges, boolean relative, boolean reverse, boolean isPointEvent) {
 		changeTimes.clear();
 
 		if (intervalTimes == null) { //equidistant
@@ -745,7 +745,7 @@ public abstract class PiecewiseBirthDeathMigrationDistribution extends SpeciesTr
 			changeTimes.add(end);
 
 		} else {
-			if (!reverse && intervalTimes.getValue(0) != 0.0 && !isPointEvent) {
+			if (!reverse && intervalTimes.getArrayValue(0) != 0.0 && !isPointEvent) {
 				throw new RuntimeException("First time in interval times parameter should always be zero.");
 			}
 
@@ -757,7 +757,7 @@ public abstract class PiecewiseBirthDeathMigrationDistribution extends SpeciesTr
 
 			double end;
 			for (int i = (reverse?0:1); i < dim; i++) {
-				end = reverse ? (maxTime - intervalTimes.getValue(dim - i - 1)) : intervalTimes.getValue(i);
+				end = reverse ? (maxTime - intervalTimes.getArrayValue(dim - i - 1)) : intervalTimes.getArrayValue(i);
 				if (relative) end *= maxTime;
 				if (end < maxTime) changeTimes.add(end); //TODO does this mean that change times can never be input in absolute time? It looks like it does.
 			}
@@ -765,7 +765,7 @@ public abstract class PiecewiseBirthDeathMigrationDistribution extends SpeciesTr
 			if (adjustTimesInput.get()!=null){
 
 				double iTime;
-				double aTime = adjustTimesInput.get().getValue();
+				double aTime = adjustTimesInput.get().getArrayValue();
 
 				for (int i = 0 ; i < numChanges; i++){
 
@@ -792,12 +792,12 @@ public abstract class PiecewiseBirthDeathMigrationDistribution extends SpeciesTr
 
 		double[] birthRates = birthRate.get().getDoubleValues();
 		double[] deathRates = deathRate.get().getDoubleValues();
-		Double[] samplingRates = samplingRate.get().getValues();
-		Double[] removalProbabilities = new Double[1];
+		double[] samplingRates = samplingRate.get().getDoubleValues();
+		double[] removalProbabilities = new double[1];
 
 		if (SAModel) {
-			removalProbabilities = removalProbability.get().getValues();
-			r =  new Double[n*totalIntervals];
+			removalProbabilities = removalProbability.get().getDoubleValues();
+			r =  new double[n*totalIntervals];
 		}
 
 		int state;
@@ -820,7 +820,7 @@ public abstract class PiecewiseBirthDeathMigrationDistribution extends SpeciesTr
 	}
 
 
-	void updateAmongParameter(Double[] param, Double[] paramFrom, int nrChanges, List<Double> changeTimes){
+	void updateAmongParameter(double[] param, double[] paramFrom, int nrChanges, List<Double> changeTimes){
 
 		for (int i = 0; i < n; i++) {
 			for (int j = 0; j < n; j++) {
@@ -840,8 +840,8 @@ public abstract class PiecewiseBirthDeathMigrationDistribution extends SpeciesTr
 	void updateRho(){
 		if (m_rho.get() != null && (m_rho.get().getDimension()==1 ||  rhoSamplingTimes.get() != null)) {
 
-			Double[] rhos = m_rho.get().getValues();
-			rho = new Double[n*totalIntervals];
+			double[] rhos = m_rho.get().getDoubleValues();
+			rho = new double[n*totalIntervals];
 			int state;
 
 			for (int i = 0; i < totalIntervals*n; i++) {
@@ -885,18 +885,18 @@ public abstract class PiecewiseBirthDeathMigrationDistribution extends SpeciesTr
 
 	public void transformWithinParameters(){
 
-		Double[] p = samplingProportion.get().getValues();
-		Double[] ds = becomeUninfectiousRate.get().getValues();
-		Double[] R;
+		double[] p = samplingProportion.get().getDoubleValues();
+		double[] ds = becomeUninfectiousRate.get().getDoubleValues();
+		double[] R;
 		if (R0.get() != null) {
-			R = R0.get().getValues();
+			R = R0.get().getDoubleValues();
 		} else {
-			Double[] l_ratio = lambda_ratio.get().getValues();
-			Double[] R_sens = R0_base.get().getValues();
+			double[] l_ratio = lambda_ratio.get().getDoubleValues();
+			double[] R_sens = R0_base.get().getDoubleValues();
 
 			int totalIntervals = R_sens.length;
 			int totalTypes = l_ratio.length + 1;
-			R = new Double[totalIntervals * totalTypes];
+			R = new double[totalIntervals * totalTypes];
 			for (int i=0; i < totalIntervals; i++) {
 				R[i] = R_sens[i];
 				for (int j=1; j < totalTypes; j++) {
@@ -906,8 +906,8 @@ public abstract class PiecewiseBirthDeathMigrationDistribution extends SpeciesTr
 			}
 		}
 
-		Double[] removalProbabilities = new Double[1];
-		if (SAModel) removalProbabilities = removalProbability.get().getValues();
+		double[] removalProbabilities = new double[1];
+		if (SAModel) removalProbabilities = removalProbability.get().getDoubleValues();
 
 		int state;
 
@@ -955,8 +955,8 @@ public abstract class PiecewiseBirthDeathMigrationDistribution extends SpeciesTr
 
 	public void transformAmongParameters(){
 
-		Double[] RaD = (birthAmongDemes) ? R0AmongDemes.get().getValues() : new Double[1];
-		Double[] ds = becomeUninfectiousRate.get().getValues();
+		double[] RaD = (birthAmongDemes) ? R0AmongDemes.get().getDoubleValues() : new double[1];
+		double[] ds = becomeUninfectiousRate.get().getDoubleValues();
 
 		if (birthAmongDemes)    {
 
@@ -999,12 +999,12 @@ public abstract class PiecewiseBirthDeathMigrationDistribution extends SpeciesTr
 
 	void updateOrigin(Node root){
 
-		T = origin.get().getValue();
+		T = origin.get().getArrayValue();
 		orig = T - root.getHeight();
 
 		if (originIsRootEdge.get()) {
 
-			orig = origin.get().getValue();
+			orig = origin.get().getArrayValue();
 			T = orig + root.getHeight();
 		}
 
@@ -1150,19 +1150,19 @@ public abstract class PiecewiseBirthDeathMigrationDistribution extends SpeciesTr
 
 		birth = new double[n*totalIntervals];
 		death = new double[n*totalIntervals];
-		psi = new Double[n*totalIntervals];
-		b_ij = new Double[totalIntervals*(n*(n-1))];
-		M = new Double[totalIntervals*(n*(n-1))];
-		if (SAModel) r =  new Double[n * totalIntervals];
+		psi = new double[n*totalIntervals];
+		b_ij = new double[totalIntervals*(n*(n-1))];
+		M = new double[totalIntervals*(n*(n-1))];
+		if (SAModel) r =  new double[n * totalIntervals];
 
 		if (transform) {
 			transformParameters();
 		}
 		else {
 
-			Double[] birthAmongDemesRates = new Double[1];
+			double[] birthAmongDemesRates = new double[1];
 
-			if (birthAmongDemes) birthAmongDemesRates = birthRateAmongDemes.get().getValues();
+			if (birthAmongDemes) birthAmongDemesRates = birthRateAmongDemes.get().getDoubleValues();
 
 			updateBirthDeathPsiParams();
 
@@ -1173,11 +1173,11 @@ public abstract class PiecewiseBirthDeathMigrationDistribution extends SpeciesTr
 		}
 
 		if (migrationMatrix.get()!=null) {
-			Double[] migRates = migrationMatrix.get().getValues();
+			double[] migRates = migrationMatrix.get().getDoubleValues();
 
-			Double factor;
+			double factor;
 			if (migrationMatrixScaleFactor.get()!=null) {
-				factor = migrationMatrixScaleFactor.get().getValue();
+				factor = migrationMatrixScaleFactor.get().getArrayValue();
 				for (int i = 0; i < migRates.length; i++) migRates[i] *= factor;
 			}
 
@@ -1194,7 +1194,7 @@ public abstract class PiecewiseBirthDeathMigrationDistribution extends SpeciesTr
 
 		updateRho();
 
-		freq = frequencies.get().getValues();
+		freq = frequencies.get().getDoubleValues();
 
 		setupIntegrators();
 
@@ -1235,9 +1235,9 @@ public abstract class PiecewiseBirthDeathMigrationDistribution extends SpeciesTr
 		int offset = getArrayOffset(i, j);
 
 		if (migrationMatrixScaleFactor.get()==null)
-			return migrationMatrix.get().getValue(offset);
+			return migrationMatrix.get().getArrayValue(offset);
 		else
-			return migrationMatrixScaleFactor.get().getValue()*migrationMatrix.get().getValue(offset);
+			return migrationMatrixScaleFactor.get().getArrayValue()*migrationMatrix.get().getArrayValue(offset);
 
 	}
 

--- a/src/bdmm/math/p0_ODE.java
+++ b/src/bdmm/math/p0_ODE.java
@@ -16,18 +16,18 @@ import bdmm.core.util.Utils;
 public class p0_ODE implements FirstOrderDifferentialEquations {
 
 	double[] b;
-	Double[] b_ij;
+	double[] b_ij;
 	double[] d;
-	Double[] s;
+	double[] s;
 
-	Double[] M;
+	double[] M;
 
 	int dimension;
 	int intervals;
-	Double[] times;
+	double[] times;
 	int index;
 
-	public p0_ODE(double[] b, Double[] b_ij, double[] d, Double[] s, Double[] M, int dimension , int intervals, Double[] times) {
+	public p0_ODE(double[] b, double[] b_ij, double[] d, double[] s, double[] M, int dimension , int intervals, double[] times) {
 
 		this.b = b;
 		this.b_ij = b_ij;
@@ -42,7 +42,7 @@ public class p0_ODE implements FirstOrderDifferentialEquations {
 	}
 
 	// updateRates is not used here because a new p0_ODE is created each time PiecewiseBirthDeathMigrationDistribution.updateRates() is called (called through setUpIntegrators())
-	public void updateRates(double[] b, Double[] b_ij, double[] d, Double[] s, Double[] M, Double[] times){
+	public void updateRates(double[] b, double[] b_ij, double[] d, double[] s, double[] M, double[] times){
 
 		this.b = b;
 		this.b_ij = b_ij;
@@ -80,7 +80,7 @@ public class p0_ODE implements FirstOrderDifferentialEquations {
 						yDot[i] -= b_ij[l]*y[i]*y[j];
 					}
 
-					if (M[0]!=null) {// migration:
+					if (M!=null) {// migration:
 						yDot[i] += M[l] * y[i];
 						yDot[i] -= M[l] * y[j];
 					}
@@ -100,11 +100,11 @@ public class p0_ODE implements FirstOrderDifferentialEquations {
 		// 2d test
 		double[] b = {1.03,1.06};
 		double[] d = {1.,1.};
-		Double[] s = {0.02,0.04};
-		Double[] M = new Double[]{3.,4.};
+		double[] s = {0.02,0.04};
+		double[] M = new double[]{3.,4.};
 
 		FirstOrderIntegrator integrator = new DormandPrince853Integrator(1.0e-8, 100.0, 1.0e-20, 1.0e-9);//new ClassicalRungeKuttaIntegrator(.01); //
-		FirstOrderDifferentialEquations ode = new p0_ODE(b,null,d,s,M, 2, 1, new Double[]{0.});
+		FirstOrderDifferentialEquations ode = new p0_ODE(b,null,d,s,M, 2, 1, new double[]{0.});
 		double[] y0 = new double[]{1.,1.};
 		double[] y = new double[2];
 

--- a/src/bdmm/math/p0ge_ODE.java
+++ b/src/bdmm/math/p0ge_ODE.java
@@ -26,19 +26,19 @@ public class p0ge_ODE implements FirstOrderDifferentialEquations {
 	public FirstOrderIntegrator p_integrator;
 
 	double[] b;
-	Double[] b_ij;
+	double[] b_ij;
 	double[] d;
-	Double[] s;
+	double[] s;
 
 	Boolean augmented;
 	Boolean birthAmongDemes;
 
-	Double[] M;
+	double[] M;
 	double T;
 
 	int dimension; /* ODE numberOfDemes = stateNumber */
 	int intervals;
-	Double[] times;
+	double[] times;
 	int index;
 
 	int maxEvals;
@@ -46,7 +46,7 @@ public class p0ge_ODE implements FirstOrderDifferentialEquations {
 	public static double globalPrecisionThreshold;
 
 
-	public p0ge_ODE(double[] b, Double[] b_ij, double[] d, Double[] s, Double[] M, int dimension, int intervals, double T, Double[] times, p0_ODE P, int maxEvals, Boolean augmented){
+	public p0ge_ODE(double[] b, double[] b_ij, double[] d, double[] s, double[] M, int dimension, int intervals, double T, double[] times, p0_ODE P, int maxEvals, Boolean augmented){
 
 
 		this.b = b;
@@ -102,7 +102,7 @@ public class p0ge_ODE implements FirstOrderDifferentialEquations {
 
 					}
 
-					if (M[0]!=null) {// migration:
+					if (M!=null) {// migration:
 						gDot[i] += M[l] * g[i];
 						gDot[i] -= M[l] * g[j];
 					}
@@ -130,7 +130,7 @@ public class p0ge_ODE implements FirstOrderDifferentialEquations {
 						}
 					}
 
-					if (M[0]!=null) {// migration:
+					if (M!=null) {// migration:
 						gDot[dimension + i] += M[l] * g[dimension + i];
 						if (!augmented) gDot[dimension + i] -= M[l] * g[dimension + j];
 					}
@@ -151,7 +151,7 @@ public class p0ge_ODE implements FirstOrderDifferentialEquations {
 	 * @param rho
 	 * @return
 	 */
-	public double[] getP(double t, double[]P0, double t0, Boolean rhoSampling, Double[] rho){
+	public double[] getP(double t, double[] P0, double t0, Boolean rhoSampling, double[] rho){
 
 
 		if (Math.abs(T-t)<globalPrecisionThreshold || Math.abs(t0-t)<globalPrecisionThreshold ||   T < t)
@@ -230,7 +230,7 @@ public class p0ge_ODE implements FirstOrderDifferentialEquations {
 	}
 
 
-	public double[] getP(double t, Boolean rhoSampling, Double[] rho){
+	public double[] getP(double t, Boolean rhoSampling, double[] rho){
 
 		double[] y = new double[dimension];
 
@@ -263,13 +263,13 @@ public class p0ge_ODE implements FirstOrderDifferentialEquations {
 
 		double[] b;
 		double[] d = {1.,1.};
-		Double[] s;
-		Double[] M;// = {3.,3.};
+		double[] s;
+		double[] M;// = {3.,3.};
 
-		Double psi;
+		double psi;
 
-		Double c1 = 0.01;
-		Double c2 = 0.1;
+		double c1 = 0.01;
+		double c2 = 0.1;
 
 
 		for (double i =1.1; i<2; i+=0.125){
@@ -279,10 +279,10 @@ public class p0ge_ODE implements FirstOrderDifferentialEquations {
 			//            psi = 0.5 * ((i - death[0]) - Math.sqrt((death[0] - i) * (death[0] - i) - .04));  // assume birth*sampling*m=constant
 
 
-			M = new Double[]{b[0]-d[0]-c2/b[0], b[0]-d[0]-c2/b[0]};     // assume birth-death-sampling=migration
+			M = new double[]{b[0]-d[0]-c2/b[0], b[0]-d[0]-c2/b[0]};     // assume birth-death-sampling=migration
 
 			psi = c2/c1 * M[0]; // assume birth*m = c1 and birth*sampling = c2
-			s = new Double[] {psi,psi};
+			s = new double[] {psi,psi};
 
 
 			FirstOrderIntegrator integrator1 = new ClassicalRungeKuttaIntegrator(.01);
@@ -298,8 +298,8 @@ public class p0ge_ODE implements FirstOrderDifferentialEquations {
 			double T = 1;
 			Boolean augmented = true;
 
-			p0_ODE p_ode = new p0_ODE(b,null, d,s,M, 2, 1, new Double[]{0.});
-			p0ge_ODE pg_ode = new p0ge_ODE(b,null, d,s,M, 2, 1, T, new Double[]{0.}, p_ode, Integer.MAX_VALUE,augmented);
+			p0_ODE p_ode = new p0_ODE(b,null, d,s,M, 2, 1, new double[]{0.});
+			p0ge_ODE pg_ode = new p0ge_ODE(b,null, d,s,M, 2, 1, T, new double[]{0.}, p_ode, Integer.MAX_VALUE,augmented);
 
 			System.out.println("birth[0] = "+b[0]+ ", death[0] = " + Math.round(d[0]*100.)/100.+ "\t\t");
 
@@ -369,8 +369,8 @@ public class p0ge_ODE implements FirstOrderDifferentialEquations {
 		double[] birth = {2.,2.};
 		double[] b;
 		double[] d = {.5,.5};
-		Double[] s = {.5,.5};
-		Double[] M = {0.,0.};
+		double[] s = {.5,.5};
+		double[] M = {0.,0.};
 
 		System.out.println("birth\tp\tg");
 
@@ -385,8 +385,8 @@ public class p0ge_ODE implements FirstOrderDifferentialEquations {
 		double T = 10.;
 		Boolean augmented = false;
 
-		p0_ODE p_ode = new p0_ODE(b,new Double[]{1.,1.}, d,s,M, 2, 1, new Double[]{0.});
-		p0ge_ODE pg_ode = new p0ge_ODE(b,new Double[]{1.,1.}, d,s,M, 2, 1, T, new Double[]{0.}, p_ode, Integer.MAX_VALUE,augmented);
+		p0_ODE p_ode = new p0_ODE(b,new double[]{1.,1.}, d,s,M, 2, 1, new double[]{0.});
+		p0ge_ODE pg_ode = new p0ge_ODE(b,new double[]{1.,1.}, d,s,M, 2, 1, T, new double[]{0.}, p_ode, Integer.MAX_VALUE,augmented);
 
 		pg_ode.p_integrator = integrator;
 		double[] p0 = new double[]{1.,1.};
@@ -398,11 +398,11 @@ public class p0ge_ODE implements FirstOrderDifferentialEquations {
 		integrator.integrate(p_ode, T, p0, 0., p);
 
 		double[] res2 = new double[] {4};
-		double[] res  = pg_ode.getP(8, false, new Double[]{0.});
+		double[] res  = pg_ode.getP(8, false, new double[]{0.});
 		System.out.println(b[0] + "\t" + res[0]+"\t"+res[1]);
-		res2 = pg_ode.getP(5, res, 8, false, new Double[]{0.});
+		res2 = pg_ode.getP(5, res, 8, false, new double[]{0.});
 		System.out.println(b[0] + "\t" + res[0]+"\t"+res[1]);
-		res2 = pg_ode.getP(0, res, 5, false, new Double[]{0.});
+		res2 = pg_ode.getP(0, res, 5, false, new double[]{0.});
 		System.out.println(b[0] + "\t" + res[0]+"\t"+res[1]);
 
 		//             System.out.print("birth[0] = "+birth[0]+ ", death[0] = " + Math.round(death[0]*100.)/100.+ "\t\t");

--- a/src/bdmm/treesimulator/RandomMultiTypeTreeFromBDMM.java
+++ b/src/bdmm/treesimulator/RandomMultiTypeTreeFromBDMM.java
@@ -6,7 +6,6 @@ import beast.base.inference.StateNode;
 import beast.base.inference.StateNodeInitialiser;
 import beast.base.inference.parameter.RealParameter;
 import beast.base.util.Randomizer;
-import beast.evolution.tree.*;
 import multitypetree.evolution.tree.MultiTypeNode;
 import multitypetree.evolution.tree.MultiTypeTree;
 

--- a/version.xml
+++ b/version.xml
@@ -1,4 +1,4 @@
-<package name="BDMM" version="2.0.0">
+<package name="BDMM" version="2.0.2-unofficial">
   <depends on='BEAST.base' atleast='2.7.2'/>
   <depends on='BEAST.app' atleast='2.7.2'/>
   <depends on="MultiTypeTree" atleast="8.0.0"/>


### PR DESCRIPTION
The previous updates to the BEAUti templates to bring them into line with BEAST 2.7 did not include the new AVMN operators used now to scale clock rates and substitution rates, making those templates incompatible with BEAST 2.7 clock and substitution model templates.  This meant that, for instance, substitution rates for models such as GTR could not be estimated, and selecting these models would instead result in silent BEAUti errors.

This update replaces those missing operators.